### PR TITLE
Corrected license

### DIFF
--- a/src/datasets/NGT_Corpus.json
+++ b/src/datasets/NGT_Corpus.json
@@ -11,6 +11,6 @@
   "#items": null,
   "#samples": "15 Hours",
   "#signers": 92,
-  "license": "CC BY 3.0 NL",
-  "licenseUrl": "https://creativecommons.org/licenses/by/3.0/nl/deed.en_GB"
+  "license": "CC BY-NC-SA 3.0 NL",
+  "licenseUrl": "https://creativecommons.org/licenses/by-nc-sa/3.0/nl/deed.en_GB"
 }


### PR DESCRIPTION
CC BY 3.0 NL only applies to the texts on the project webpage. License for the data is CC BY-NC-SA 3.0 NL for video recordings and CC BY-NC-SA 4.0 for annotation files. See https://archive.mpi.nl/tla/islandora/object/tla%3A1839_00_0000_0000_0021_6AC3_1