### PR TITLE
Small change, create subheading for datasets on main page.

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1046,6 +1046,7 @@ Furthermore, we follow a unified interface when possible, making attributes the 
 }
 ```
 
+## List of Datasets
 
 The following table contains a curated list of datasets, including various signed languages and data formats:
 


### PR DESCRIPTION
Just adding `## List of Datasets` so that the table of contents will have a quick-access link