### PR TITLE
Add ISLTranslate to table, paper description to site

### DIFF
--- a/src/datasets/ISLTranslate.json
+++ b/src/datasets/ISLTranslate.json
@@ -7,7 +7,7 @@
     },
     
     "#items": 11000, 
-    "#samples": "31k ISL-English sentence/phrase pairs",
+    "#samples": "31k sentences",
     "#signers": null, 
     "features": ["video", "text:English", "pose:MediaPipe"],
     "language": "Indian", 

--- a/src/datasets/ISLTranslate.json
+++ b/src/datasets/ISLTranslate.json
@@ -1,0 +1,16 @@
+{
+    "pub": {
+      "name": "ISLTranslate",
+      "year": "2023",
+      "publication": "dataset:joshi-etal-2023-isltranslate",
+      "url": "https://github.com/Exploration-Lab/ISLTranslate"
+    },
+    
+    "#items": 11000, 
+    "#samples": "31k ISL-English sentence/phrase pairs",
+    "#signers": null, 
+    "features": ["video", "text:English", "pose:MediaPipe"],
+    "language": "Indian", 
+    "license": "License: CC BY-NC 4.0",
+    "licenseUrl":"https://creativecommons.org/licenses/by-nc/4.0/"
+  }

--- a/src/index.md
+++ b/src/index.md
@@ -726,8 +726,6 @@ The model features shared representations for different modalities such as text 
 on several tasks such as video-to-gloss, gloss-to-text, and video-to-text. 
 The approach allows leveraging external data such as parallel data for spoken language machine translation.
 
-@dataset:joshi-etal-2023-isltranslate introduce ISLTranslate, a large translation dataset for Indian Sign Language based on publicly available educational videos intended for hard-of-hearing children, which happen to contain both ISL and English audio voiceover conveying the same content. They use a speech-to-text model to transcribe the audio content, which they later manually corrected with the help of accompanying books also containing the same content. They also use MediaPipe to extract pose features, and have a certified ISL signer validate a small portion of the sign-text pairs. They provide a baseline based on the architecture proposed in @camgoz2020sign, and provide code.
-
 <!-- TODO: AFRISIGN (Shester and Mathias at AfricaNLP, ICLR 2023 workshop) -->
 
 #### Text-to-Video
@@ -927,6 +925,12 @@ Some special features are cross-level links, non-temporal objects, timepoint tra
 Anvil installation is [available](https://www.anvil-software.org/download/index.html) for Windows, macOS, and Linux.
 
 ## Resources
+
+###### Dataset Papers
+
+Research papers which do not necessarily contribute new theory or architectures are actually important and useful enablers of other research. Furthermore, the advancement of the dataset creation process itself is important, and the pipeline of creation and curation is a potential target for improvements and advancements.
+
+@dataset:joshi-etal-2023-isltranslate introduce ISLTranslate, a large translation dataset for Indian Sign Language based on publicly available educational videos intended for hard-of-hearing children, which happen to contain both Indian Sign Language and English audio voiceover conveying the same content. They use a speech-to-text model to transcribe the audio content, which they later manually corrected with the help of accompanying books also containing the same content. They also use MediaPipe to extract pose features, and have a certified ISL signer validate a small portion of the sign-text pairs. They provide a baseline based on the architecture proposed in @camgoz2020sign, and provide code.
 
 ###### Bilingual dictionaries {-}
 for signed language [@dataset:mesch2012meaning;@fenlon2015building;@crasborn2016ngt;@dataset:gutierrez2016lse] map a spoken language word or short phrase to a signed language video.

--- a/src/index.md
+++ b/src/index.md
@@ -726,6 +726,8 @@ The model features shared representations for different modalities such as text 
 on several tasks such as video-to-gloss, gloss-to-text, and video-to-text. 
 The approach allows leveraging external data such as parallel data for spoken language machine translation.
 
+@dataset:joshi-etal-2023-isltranslate introduce ISLTranslate, a large translation dataset for Indian Sign Language based on publicly available educational videos intended for hard-of-hearing children, which happen to contain both ISL and English audio voiceover conveying the same content. They use a speech-to-text model to transcribe the audio content, which they later manually corrected with the help of accompanying books also containing the same content. They also use MediaPipe to extract pose features, and have a certified ISL signer validate a small portion of the sign-text pairs. They provide a baseline based on the architecture proposed in @camgoz2020sign, and provide code.
+
 <!-- TODO: AFRISIGN (Shester and Mathias at AfricaNLP, ICLR 2023 workshop) -->
 
 #### Text-to-Video

--- a/src/references.bib
+++ b/src/references.bib
@@ -2136,3 +2136,19 @@
   year={2021},
   publisher={Oxford University Press}
 }
+
+
+
+@inproceedings{dataset:joshi-etal-2023-isltranslate,
+    title = "{ISLT}ranslate: Dataset for Translating {I}ndian {S}ign {L}anguage",
+    author = "Joshi, Abhinav  and
+      Agrawal, Susmit  and
+      Modi, Ashutosh",
+    booktitle = "Findings of the Association for Computational Linguistics: ACL 2023",
+    month = jul,
+    year = "2023",
+    address = "Toronto, Canada",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2023.findings-acl.665",
+    pages = "10466--10475"
+}


### PR DESCRIPTION
Might be good to also add a short summary to the  https://research.sign.mt/#sign-language-recognition-translation-and-production section. Something like "Joshi et al build on code from Camgoz and establish a baseline for ISL-to-English translation", and then also cite 

```
@inproceedings{camgoz2020sign,
  title = {Sign Language Transformers: {{Joint}} End-to-End Sign Language Recognition and Translation},
  booktitle = {Proceedings of the {{IEEE}}/{{CVF}} Conference on Computer Vision and Pattern Recognition},
  author = {Camg{\"o}z, Necati Cihan and Koller, Oscar and Hadfield, Simon and Bowden, Richard},
  year = {2020},
  pages = {10023--10033}
}

```