### PR TITLE
Adding "Querying A Sign Language Dictionary with Videos Using Dense Vector Search" and add SL Retrieval section

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -862,15 +862,7 @@ Sign Language Retrieval is the task of finding a particular data item, given som
 <!-- with video -->
 #### Sign Video to Sign Video
 
-@costerQueryingSignLanguage2023 describe a proof of concept system which would allow users of an online dictionary of signs to search _by signing_, a more user-friendly method.
-That is, by recording and uploading a video of themselves signing, one can query the dictionary that way.
-They do this by essentially by finding the video with the most similar embeddings.
-They start by first pretraining a Sign Language Recognition (Pose sequence to Gloss) model, thus training their transformer encoder to embed sign inputs.
-<!-- Specifically a modified PoseFormer, according to the Repo. In the paper, Coster et al cite Sign Language Recognition with Transformer Networks (2020). https://aclanthology.org/2020.lrec-1.737/ -->
-Once the encoder is trained, then they can use it to generate embeddings for all the signs in the dictionary.
-When a user input query video arrives they can then compare the embeddings of the input to those of dictionary entries using Euclidean distance.
-[A prototype repository is provided](https://github.com/m-decoster/VGT-SL-Dictionary), including scripts to generate a database for a dictionary as well as documentation for installation or training of new models.
-<!-- TODO: De Coster cites Fink et al aka Dictionnaire contextuel langue des signes belge francophone vers français and says they have one working? Transformer-based. https://dico.corpus-lsfb.be/-->
+@costerQueryingSignLanguage2023 present a proof of concept for a sign language dictionary that allows users to search by signing. Users can record a video of themselves signing and upload it to query the dictionary. This system works by finding the video with the most similar embeddings. The process begins with pretraining a [Sign Language Recognition model](#pose-to-gloss) to embed sign inputs. Once the encoder is trained, it generates embeddings for all dictionary signs. When a user submits a query video, the system compares the input embeddings with those of the dictionary entries using Euclidean distance. Tests on a Flemish Sign Language dictionary show that the system can successfully retrieve a limited vocabulary of signs, including some not in the training set. A prototype repository is available, including scripts for database generation and documentation for model installation or training.
 
 ### Fingerspelling
 

--- a/src/index.md
+++ b/src/index.md
@@ -860,11 +860,11 @@ Sign Language Retrieval is the task of finding a particular data item, given som
 <!-- TODO: CiCo: Domain-Aware Sign Language Retrieval via Cross-Lingual Contrastive Learning -->
 
 @costerQueryingSignLanguage2023 present a method to query sign language dictionaries using dense vector search.
-They pretrain a [Sign Language Recognition model](#pose-to-gloss) on a subset of the [VGT corpus](https://corpusvgt.be/) to embed sign inputs.
+They pretrain a [Sign Language Recognition model](#pose-to-gloss) on a subset of the VGT corpus [@dataset:herreweghe2015VGTCorpus] to embed sign inputs.
 Once the encoder is trained, they use it to generate embeddings for all dictionary signs.
 When a user submits a query video, the system compares the input embeddings with those of the dictionary entries using Euclidean distance.
 Tests on a [proof-of-concept Flemish Sign Language dictionary](https://github.com/m-decoster/VGT-SL-Dictionary) show that the system can successfully retrieve a limited vocabulary of signs, including some not in the training set.
-<!-- TODO: add VGT Corpus to list of datasets -->
+<!-- TODO: add VGT Corpus (dataset:herreweghe2015VGTCorpus) to list of datasets -->
 
 ### Fingerspelling
 

--- a/src/index.md
+++ b/src/index.md
@@ -299,6 +299,7 @@ encoding subtitles by BERT [@devlin-etal-2019-bert] and videos by CNN video repr
 
 <!-- @segmentation:de-sisto-etal-2021-defining introduce a proposal for mapping segments to meaning in the form of an agglomerate of lexical and non-lexical information. -->
 
+
 ### Sign Language Recognition, Translation, and Production
 
 Sign language translation (SLT) commonly refers to the translation of signed language to spoken language [@de2022machine;@muller-etal-2022-findings].
@@ -851,6 +852,25 @@ TODO
 
 ```
 
+### Sign Language Retrieval
+
+Sign Language Retrieval is the task of finding a particular data item, given some input. In contrast to translation or generation or production tasks, there exists a correct corresponding piece of data already, the task is simply to find the correct one out of many.
+
+<!-- TODO: text-to-sign-video (T2V) section, sign-video-to-text (V2T) retrieval -->
+<!-- TODO: CiCo: Domain-Aware Sign Language Retrieval via Cross-Lingual Contrastive Learning -->
+
+<!-- with video -->
+#### Sign Video to Sign Video
+
+@costerQueryingSignLanguage2023 describe a proof of concept system which would allow users of an online dictionary of signs to search _by signing_, a more user-friendly method.
+That is, by recording and uploading a video of themselves signing, one can query the dictionary that way.
+They do this by essentially by finding the video with the most similar embeddings.
+They start by first pretraining a Sign Language Recognition (Pose sequence to Gloss) model, thus training their transformer encoder to embed sign inputs.
+<!-- Specifically a modified PoseFormer, according to the Repo. In the paper, Coster et al cite Sign Language Recognition with Transformer Networks (2020). https://aclanthology.org/2020.lrec-1.737/ -->
+Once the encoder is trained, then they can use it to generate embeddings for all the signs in the dictionary.
+When a user input query video arrives they can then compare the embeddings of the input to those of dictionary entries using Euclidean distance.
+[A prototype repository is provided](https://github.com/m-decoster/VGT-SL-Dictionary), including scripts to generate a database for a dictionary as well as documentation for installation or training of new models.
+<!-- TODO: De Coster cites Fink et al aka Dictionnaire contextuel langue des signes belge francophone vers français and says they have one working? Transformer-based. https://dico.corpus-lsfb.be/-->
 
 ### Fingerspelling
 

--- a/src/index.md
+++ b/src/index.md
@@ -859,14 +859,11 @@ Sign Language Retrieval is the task of finding a particular data item, given som
 <!-- TODO: text-to-sign-video (T2V) section, sign-video-to-text (V2T) retrieval -->
 <!-- TODO: CiCo: Domain-Aware Sign Language Retrieval via Cross-Lingual Contrastive Learning -->
 
-@costerQueryingSignLanguage2023 present a proof of concept for a sign language dictionary that allows users to search by signing.
-Users can record a video of themselves signing and upload it to query the dictionary.
-This system works by finding the video with the most similar embeddings.
-The process begins with pretraining a [Sign Language Recognition model](#pose-to-gloss) to embed sign inputs.
-Once the encoder is trained, it generates embeddings for all dictionary signs.
+@costerQueryingSignLanguage2023 present a method to query sign language dictionaries using dense vector search.
+They pretrain a [Sign Language Recognition model](#pose-to-gloss) on a subset of the VGT corpus to embed sign inputs.
+Once the encoder is trained, they use it to generate embeddings for all dictionary signs.
 When a user submits a query video, the system compares the input embeddings with those of the dictionary entries using Euclidean distance.
-Tests on a Flemish Sign Language dictionary show that the system can successfully retrieve a limited vocabulary of signs, including some not in the training set.
-[A prototype repository](https://github.com/m-decoster/VGT-SL-Dictionary) is available, including scripts for database generation and documentation for model installation or training.
+Tests on a [proof-of-concept Flemish Sign Language dictionary](https://github.com/m-decoster/VGT-SL-Dictionary) show that the system can successfully retrieve a limited vocabulary of signs, including some not in the training set.
 
 ### Fingerspelling
 

--- a/src/index.md
+++ b/src/index.md
@@ -860,10 +860,11 @@ Sign Language Retrieval is the task of finding a particular data item, given som
 <!-- TODO: CiCo: Domain-Aware Sign Language Retrieval via Cross-Lingual Contrastive Learning -->
 
 @costerQueryingSignLanguage2023 present a method to query sign language dictionaries using dense vector search.
-They pretrain a [Sign Language Recognition model](#pose-to-gloss) on a subset of the VGT corpus to embed sign inputs.
+They pretrain a [Sign Language Recognition model](#pose-to-gloss) on a subset of the [VGT corpus](https://corpusvgt.be/) to embed sign inputs.
 Once the encoder is trained, they use it to generate embeddings for all dictionary signs.
 When a user submits a query video, the system compares the input embeddings with those of the dictionary entries using Euclidean distance.
 Tests on a [proof-of-concept Flemish Sign Language dictionary](https://github.com/m-decoster/VGT-SL-Dictionary) show that the system can successfully retrieve a limited vocabulary of signs, including some not in the training set.
+<!-- TODO: add VGT Corpus to list of datasets -->
 
 ### Fingerspelling
 

--- a/src/index.md
+++ b/src/index.md
@@ -854,7 +854,7 @@ TODO
 
 ### Sign Language Retrieval
 
-Sign Language Retrieval is the task of finding a particular data item, given some input. In contrast to translation or generation or production tasks, there exists a correct corresponding piece of data already, the task is simply to find the correct one out of many.
+Sign Language Retrieval is the task of finding a particular data item, given some input. In contrast to translation, generation or production tasks, there can exist a correct corresponding piece of data already, and the task is to find it out of many, if it exists.
 
 <!-- TODO: text-to-sign-video (T2V) section, sign-video-to-text (V2T) retrieval -->
 <!-- TODO: CiCo: Domain-Aware Sign Language Retrieval via Cross-Lingual Contrastive Learning -->

--- a/src/index.md
+++ b/src/index.md
@@ -859,10 +859,14 @@ Sign Language Retrieval is the task of finding a particular data item, given som
 <!-- TODO: text-to-sign-video (T2V) section, sign-video-to-text (V2T) retrieval -->
 <!-- TODO: CiCo: Domain-Aware Sign Language Retrieval via Cross-Lingual Contrastive Learning -->
 
-<!-- with video -->
-#### Sign Video to Sign Video
-
-@costerQueryingSignLanguage2023 present a proof of concept for a sign language dictionary that allows users to search by signing. Users can record a video of themselves signing and upload it to query the dictionary. This system works by finding the video with the most similar embeddings. The process begins with pretraining a [Sign Language Recognition model](#pose-to-gloss) to embed sign inputs. Once the encoder is trained, it generates embeddings for all dictionary signs. When a user submits a query video, the system compares the input embeddings with those of the dictionary entries using Euclidean distance. Tests on a Flemish Sign Language dictionary show that the system can successfully retrieve a limited vocabulary of signs, including some not in the training set. A prototype repository is available, including scripts for database generation and documentation for model installation or training.
+@costerQueryingSignLanguage2023 present a proof of concept for a sign language dictionary that allows users to search by signing.
+Users can record a video of themselves signing and upload it to query the dictionary.
+This system works by finding the video with the most similar embeddings.
+The process begins with pretraining a [Sign Language Recognition model](#pose-to-gloss) to embed sign inputs.
+Once the encoder is trained, it generates embeddings for all dictionary signs.
+When a user submits a query video, the system compares the input embeddings with those of the dictionary entries using Euclidean distance.
+Tests on a Flemish Sign Language dictionary show that the system can successfully retrieve a limited vocabulary of signs, including some not in the training set.
+[A prototype repository](https://github.com/m-decoster/VGT-SL-Dictionary) is available, including scripts for database generation and documentation for model installation or training.
 
 ### Fingerspelling
 

--- a/src/references.bib
+++ b/src/references.bib
@@ -2185,3 +2185,11 @@
   doi={10.1109/ICASSPW59220.2023.10193531}
 }
 
+@misc{dataset:herreweghe2015VGTCorpus,
+  author       = {{Van Herreweghe, Mieke and Vermeerbergen, Myriam and Demey, Eline and De Durpel, Hannes and Nyffels, Hilde and Verstraete, Sam}},
+  keywords     = {{Vlaamse Gebarentaal,Corpuslinguïstiek}},
+  language     = {{dut}},
+  title        = {{Het Corpus VGT. Een digitaal open access corpus van videos and annotaties van Vlaamse Gebarentaal, ontwikkeld aan de Universiteit Gent ism KU Leuven. <www.corpusvgt.be>}},
+  url          = {{http://www.corpusvgt.ugent.be/}},
+  year         = {{2015}},
+}

--- a/src/references.bib
+++ b/src/references.bib
@@ -2176,13 +2176,12 @@
   langid = {english}
 }
 
-@INPROCEEDINGS{costerQueryingSignLanguage2023,
+@inproceedings{costerQueryingSignLanguage2023,
   author={Coster, Mathieu De and Dambre, Joni},
   booktitle={2023 IEEE International Conference on Acoustics, Speech, and Signal Processing Workshops (ICASSPW)}, 
   title={Querying A Sign Language Dictionary with Videos Using Dense Vector Search}, 
   year={2023},
-  volume={},
-  number={},
   pages={1-5},
-  doi={10.1109/ICASSPW59220.2023.10193531}}
+  doi={10.1109/ICASSPW59220.2023.10193531}
+}
 

--- a/src/references.bib
+++ b/src/references.bib
@@ -2176,14 +2176,13 @@
   langid = {english}
 }
 
-@inproceedings{costerQueryingSignLanguage2023,
-  title = {Querying {{A Sign Language Dictionary}} with {{Videos Using Dense Vector Search}}},
-  booktitle = {2023 {{IEEE International Conference}} on {{Acoustics}}, {{Speech}}, and {{Signal Processing Workshops}} ({{ICASSPW}})},
-  author = {Coster, Mathieu De and Dambre, Joni},
-  year = {2023},
-  month = jun,
-  pages = {1--5},
-  doi = {10.1109/ICASSPW59220.2023.10193531},
-  url = {https://ieeexplore.ieee.org/document/10193531},
-  urldate = {2024-03-13}
-}
+@INPROCEEDINGS{costerQueryingSignLanguage2023,
+  author={Coster, Mathieu De and Dambre, Joni},
+  booktitle={2023 IEEE International Conference on Acoustics, Speech, and Signal Processing Workshops (ICASSPW)}, 
+  title={Querying A Sign Language Dictionary with Videos Using Dense Vector Search}, 
+  year={2023},
+  volume={},
+  number={},
+  pages={1-5},
+  doi={10.1109/ICASSPW59220.2023.10193531}}
+

--- a/src/references.bib
+++ b/src/references.bib
@@ -2175,3 +2175,15 @@
   urldate = {2024-05-13},
   langid = {english}
 }
+
+@inproceedings{costerQueryingSignLanguage2023,
+  title = {Querying {{A Sign Language Dictionary}} with {{Videos Using Dense Vector Search}}},
+  booktitle = {2023 {{IEEE International Conference}} on {{Acoustics}}, {{Speech}}, and {{Signal Processing Workshops}} ({{ICASSPW}})},
+  author = {Coster, Mathieu De and Dambre, Joni},
+  year = {2023},
+  month = jun,
+  pages = {1--5},
+  doi = {10.1109/ICASSPW59220.2023.10193531},
+  url = {https://ieeexplore.ieee.org/document/10193531},
+  urldate = {2024-03-13}
+}


### PR DESCRIPTION
Adding https://ieeexplore.ieee.org/document/10193531, aka costerQueryingSignLanguage2023

Note that I also added it to a new section, "Sign Language Retrieval", to which I intend to add https://arxiv.org/abs/2303.12793 as well. Would appreciate thoughts on whether that makes sense, or we ought to add the paper elsewhere/organize things differently.

Edit: My original summary and ChatGPT rewrite: https://chat.openai.com/share/d635924e-07f6-4642-9850-d1433b47b9b4