### PR TITLE
Adding "LLMs are Good Sign Language Translators"

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -734,6 +734,10 @@ Evaluation on the RWTH-PHOENIX-Weather-2014T [@cihan2018neural] and CSL-Daily [@
 They provide a [code implementation](https://github.com/rzhao-zhsq/CV-SLT) based largely on @chenSimpleMultiModalityTransfer2022a.
 <!-- The CV-SLT code looks pretty nice! Conda env file, data prep, not too old, paths in .yaml files, checkpoints provided (including the ones for replication), commands to train and evaluate, very nice -->
 
+@gongLLMsAreGood2024 Task is SLT. Harness off-the-shelf LLM knowledge. You give it a video. They use a Vector-Quantized Visual Sign Module to tokenize the signs into "character-level" tokens (what does this mean?). This is then passed to a Codebook Reconstruction and Alignment Module which takes in the character-level sign tokens and groups them into "words" (what do they mean?). So instead of S2 S3 S4 SM S5 S1 it will group them into words like "S2S3S4 SMS5 S1". Then you have essentially got tokens much more in the style of what LLMs are used to. Then it seems they do a cross-lingual alignment between LLM's token space and the Sign Token Space spaces using Maximum Mean Discrepancy (MMD), which lets them "narrow the gap" between the distributions. Tested on RWTH-PHOENIX-2014T and CSL-Daily, showing improvements on all metrics. Gloss-free framework, that is nice, they "follow previous". No code released.
+<!-- TODO: the "previous gloss-free frameworks are: Gloss Attention for Gloss-free Sign Language Translation (2023) and Gloss-free sign language translation: Improving from visual-language pretraining, 2023 -->
+
+
 <!-- TODO: AFRISIGN (Shester and Mathias at AfricaNLP, ICLR 2023 workshop) -->
 
 #### Text-to-Video

--- a/src/index.md
+++ b/src/index.md
@@ -734,9 +734,16 @@ Evaluation on the RWTH-PHOENIX-Weather-2014T [@cihan2018neural] and CSL-Daily [@
 They provide a [code implementation](https://github.com/rzhao-zhsq/CV-SLT) based largely on @chenSimpleMultiModalityTransfer2022a.
 <!-- The CV-SLT code looks pretty nice! Conda env file, data prep, not too old, paths in .yaml files, checkpoints provided (including the ones for replication), commands to train and evaluate, very nice -->
 
-@gongLLMsAreGood2024 Task is SLT. Harness off-the-shelf LLM knowledge. You give it a video. They use a Vector-Quantized Visual Sign Module to tokenize the signs into "character-level" tokens (what does this mean?). This is then passed to a Codebook Reconstruction and Alignment Module which takes in the character-level sign tokens and groups them into "words" (what do they mean?). So instead of S2 S3 S4 SM S5 S1 it will group them into words like "S2S3S4 SMS5 S1". Then you have essentially got tokens much more in the style of what LLMs are used to. Then it seems they do a cross-lingual alignment between LLM's token space and the Sign Token Space spaces using Maximum Mean Discrepancy (MMD), which lets them "narrow the gap" between the distributions. Tested on RWTH-PHOENIX-2014T and CSL-Daily, showing improvements on all metrics. Gloss-free framework, that is nice, they "follow previous". No code released.
-<!-- TODO: the "previous gloss-free frameworks are: Gloss Attention for Gloss-free Sign Language Translation (2023) and Gloss-free sign language translation: Improving from visual-language pretraining, 2023 -->
 
+<!-- TODO: the "previous gloss-free frameworks" that gongLLMsAreGood2024 cite are: Gloss Attention for Gloss-free Sign Language Translation (2023) and Gloss-free sign language translation: Improving from visual-language pretraining, 2023 aka GFSLT-VLP. Could be good to lead into it with explanations of those? -->
+<!--  TODO: gongLLMsAreGood2024 also cite Gloss frameworks SLTUNet and "TS-SLT", which is Two-stream network for sign language recognition and translation. Potentially, doing a section on with/without gloss would be interesting? -->
+@gongLLMsAreGood2024 introduce SignLLM, a framework for Gloss-Free Sign Language Translation that leverages the strengths of large language models (LLMs).
+SignLLM converts sign videos into language-like representations compatible with LLMs through two modules: (1) The Vector-Quantized Visual Sign (VQ-Sign) module, which translates sign videos into discrete character-level tokens, and (2) the Codebook Reconstruction and Alignment (CRA) module, which restructures these tokens into word-level representations.
+During inference, the word-level tokens are projected into the LLM's embedding space, which is then prompted for translation.
+The LLM itself can be taken "off the shelf" and does not need to be trained.
+In training, the VQ-Sign character-level module is trained with a context prediction task, the CRA word-level module with an optimal transport technique, and a sign-text alignment loss further enhances the semantic alignment between sign and text tokens.
+The framework achieves state-of-the-art results on RWTH-PHOENIX-Weather-2014T [@cihan2018neural] and CSL-Daily [@dataset:huang2018video] datasets without relying on gloss annotations.
+<!-- TODO: c.f. SignLLM with https://github.com/sign-language-processing/sign-vq? -->
 
 <!-- TODO: AFRISIGN (Shester and Mathias at AfricaNLP, ICLR 2023 workshop) -->
 

--- a/src/references.bib
+++ b/src/references.bib
@@ -2175,3 +2175,19 @@
   urldate = {2024-05-13},
   langid = {english}
 }
+
+
+@misc{gongLLMsAreGood2024,
+  title = {{{LLMs}} Are {{Good Sign Language Translators}}},
+  author = {Gong, Jia and Foo, Lin Geng and He, Yixuan and Rahmani, Hossein and Liu, Jun},
+  year = {2024},
+  month = apr,
+  number = {arXiv:2404.00925},
+  eprint = {2404.00925},
+  primaryclass = {cs},
+  publisher = {arXiv},
+  url = {http://arxiv.org/abs/2404.00925},
+  urldate = {2024-05-10},
+  archiveprefix = {arxiv},
+  langid = {english}
+}


### PR DESCRIPTION
Recent paper with good results, one of the ones from "Awesome" list. The paper's results had not yet been added to https://paperswithcode.com/sota/gloss-free-sign-language-translation-on-csl so I took the liberty of doing that.

My informal tl;dr would be: Multilingual LLMs are really good at low-resource MT. Can we reformat SL videos into something more compatible with them? Well if we use Vector Quantization to tokenize to "character"-level tokens, then group those tokens into "words" with Optimal Transport, then we have a word-level token "sentence" that LLMs know how to handle. And then you cross-lingual align using MMD to get the tokens to be even more semantically similar. Then you just give it to the LLM and prompt it to translate. And it seems to work well! Without glosses! 

Here are my notes on this process. I'm reasonably happy with the summary in terms of accuracy and conciseness, I'm now thinking of how to add value on top of this. Beyond just re-wording and re-summarizing, what would I want to see if I was reading a lit review? Probably a higher-level view, connections with other papers, etc.? 

One thing to consider might be a section on gloss-free techniques, and tie it in with https://aclanthology.org/2023.acl-short.60/