### PR TITLE
Adding "CiCo: Domain-Aware Sign Language Retrieval via Cross-Lingual Contrastive Learning"

### DIFF
--- a/src/datasets/ASLLVD.json
+++ b/src/datasets/ASLLVD.json
@@ -2,7 +2,7 @@
   "pub": {
     "name": "ASLLVD",
     "year": 2008,
-    "publication": "dataset:athitsos2008american",
+    "publication": "dataset:athitsos2008american,athitsos2010LargeLexiconIndexingRetrieval",
     "url": "https://crystal.uta.edu/~athitsos/projects/asl_lexicon/"
   },
   "features": ["gloss:ASL", "video:RGB"],

--- a/src/index.md
+++ b/src/index.md
@@ -913,7 +913,7 @@ On target datasets with continuous signing videos, they use this model with a sl
 The two encoders each pre-extract features from videos, which are then fused via a weighted sum.
 Cross-lingual contrastive learning [@Radford2021LearningTV] is then applied to align the extracted features with paired texts within a shared embedding space.
 This allows the calculation of similarity scores between text and video embeddings, and thus retrieval in either direction.
-Evaluations on How2Sign [@dataset:duarte2020how2sign] and RWTH-PHOENIX-Weather 2014T datasets [@cihan2018neural] demonstrate  improvment over the previous state of the art method [@Duarte2022SignVideoRetrivalWithTextQueries].
+Evaluations on the How2Sign [@dataset:duarte2020how2sign] and RWTH-PHOENIX-Weather 2014T [@cihan2018neural] datasets demonstrate improvement over the previous state-of-the-art [@Duarte2022SignVideoRetrivalWithTextQueries].
 Baseline retrieval results are also provided for the CSL-Daily dataset [@dataset:Zhou2021_SignBackTranslation_CSLDaily].
 
 <!-- TODO: tie in with Automatic Dense Annotation of Large-Vocabulary Sign Language Videos, mentioned in video-to-gloss? Also uses Pseudo-labeling -->

--- a/src/index.md
+++ b/src/index.md
@@ -742,7 +742,7 @@ and so they have broken the dependency upon costly annotated gloss information i
 @chen2022TwoStreamNetworkSign present a two-stream network for sign language recognition (SLR) and translation (SLT), utilizing a dual visual encoder architecture to encode RGB video frames and pose keypoints in separate streams. 
 These streams interact via bidirectional lateral connections. 
 For SLT, the visual encoders based on an S3D backbone [@xie2018SpatiotemporalS3D] output to a multilingual translation network using mBART [@liu-etal-2020-multilingual-denoising]. 
-The model achieves state-of-the-art performance on the RWTH-PHOENIX-Weather-2014 [@dataset:forster2014extensions], RWTH-PHOENIX-Weather-2014T [@cihan2018neural] and CSL-Daily [@dataset:huang2018video] datasets.
+The model achieves state-of-the-art performance on the RWTH-PHOENIX-Weather-2014 [@dataset:forster2014extensions], RWTH-PHOENIX-Weather-2014T [@cihan2018neural] and CSL-Daily [@dataset:Zhou2021_SignBackTranslation_CSLDaily] datasets.
 
 @zhang2023sltunet propose a multi-modal, multi-task learning approach to end-to-end sign language translation. 
 The model features shared representations for different modalities such as text and video and is trained jointly 
@@ -753,7 +753,7 @@ The approach allows leveraging external data such as parallel data for spoken la
 Their approach involves guiding the model to encode visual and textual data similarly through two paths: one with visual data alone and one with both modalities.
 Using KL divergences, they steer the model towards generating consistent embeddings and accurate outputs regardless of the path.
 Once the model achieves consistent performance across paths, it can be utilized for translation without gloss supervision.
-Evaluation on the RWTH-PHOENIX-Weather-2014T [@cihan2018neural] and CSL-Daily [@dataset:huang2018video] datasets demonstrates its efficacy.
+Evaluation on the RWTH-PHOENIX-Weather-2014T [@cihan2018neural] and CSL-Daily [@dataset:Zhou2021_SignBackTranslation_CSLDaily] datasets demonstrates its efficacy.
 They provide a [code implementation](https://github.com/rzhao-zhsq/CV-SLT) based largely on @chenSimpleMultiModalityTransfer2022a.
 <!-- The CV-SLT code looks pretty nice! Conda env file, data prep, not too old, paths in .yaml files, checkpoints provided (including the ones for replication), commands to train and evaluate, very nice -->
 
@@ -765,7 +765,7 @@ SignLLM converts sign videos into discrete and hierarchical representations comp
 During inference, the "word-level" tokens are projected into the LLM's embedding space, which is then prompted for translation.
 The LLM itself can be taken "off the shelf" and does not need to be trained.
 In training, the VQ-Sign "character-level" module is trained with a context prediction task, the CRA "word-level" module with an optimal transport technique, and a sign-text alignment loss further enhances the semantic alignment between sign and text tokens.
-The framework achieves state-of-the-art results on the RWTH-PHOENIX-Weather-2014T [@cihan2018neural] and CSL-Daily [@dataset:huang2018video] datasets without relying on gloss annotations.
+The framework achieves state-of-the-art results on the RWTH-PHOENIX-Weather-2014T [@cihan2018neural] and CSL-Daily [@dataset:Zhou2021_SignBackTranslation_CSLDaily] datasets without relying on gloss annotations.
 <!-- TODO: c.f. SignLLM with https://github.com/sign-language-processing/sign-vq? -->
 
 <!-- TODO: YoutubeASL explanation would fit nicely here before Rust et al 2024. They don't just do data IIRC. -->
@@ -901,36 +901,36 @@ TODO
 
 ### Sign Language Retrieval
 
-Sign Language Retrieval is the task of finding a particular data item, given some input. In contrast to translation, generation or production tasks, there can exist a correct corresponding piece of data already, and the task is to find it out of many, if it exists.
-
-Metrics used include retrieval at Rank K and (R@K, higher is better) and median rank (MedR, lower is better).
+Sign Language Retrieval is the task of finding a particular data item, given some input. In contrast to translation, generation or production tasks, there can exist a correct corresponding piece of data already, and the task is to find it out of many, if it exists. Metrics used include retrieval at Rank K and (R@K, higher is better) and median rank (MedR, lower is better).
 
 <!-- TODO: text-to-sign-video (T2V) section, sign-video-to-text (V2T) retrieval? -->
-@athitsos2010LargeLexiconIndexingRetrieval present one of the early works in this task, using a method based on hand centroids and dynamic time warping to enable users to submit videos of a sign and thus query within the ASL Lexicon Video Dataset [@dataset:athitsos2008american].
+@athitsos2010LargeLexiconIndexingRetrieval present one of the early works on this task, using a method based on hand centroids and dynamic time warping to enable users to submit videos of a sign and thus query within the ASL Lexicon Video Dataset [@dataset:athitsos2008american].
 
 @Zhang2010RevisedEditDistanceSignVideoRetrieval provide another early method for video-based querying.
 They use classical image feature extraction methods to calculate movement trajectories.
 They then use modified string edit distances between these trajectories as a way to find similar videos.
 
-<!-- TODO: write about SPOT-ALIGN. Cheng2023CiCoSignLanguageRetrieval say retrival is "recently introduced... by SPOT-ALIGN" and cite Amanda Duarte, Samuel Albanie, Xavier Gir ́ o-i Nieto, and G ̈ ul Varol. Sign language video retrieval with free-form textual queries. -->
+<!-- TODO: write here about SPOT-ALIGN aka Duarte2022SignVideoRetrivalWithTextQueries. Cheng2023CiCoSignLanguageRetrieval say retrival is "recently introduced... by SPOT-ALIGN" and cite Amanda Duarte, Samuel Albanie, Xavier Gir ́ o-i Nieto, and G ̈ ul Varol. Sign language video retrieval with free-form textual queries. Also Sign language video retrieval with free-form textual queries was the only other paper that Cheng2023CiCoSignLanguageRetrieval compared with. -->
+
+<!-- TODO: write here also about jui-etal-2022-machine, the other paper cited by Cheng2023CiCoSignLanguageRetrieval for "Previous methods [16, 18] have demonstrated the feasibility of transferring a sign encoder pre-trained on large-scale sign-spotting data into downstream tasks." -->
 
 @costerQueryingSignLanguage2023 present a method to query sign language dictionaries using dense vector search.
 They pretrain a [Sign Language Recognition model](#pose-to-gloss) on a subset of the VGT corpus [@dataset:herreweghe2015VGTCorpus] to embed sign inputs.
 Once the encoder is trained, they use it to generate embeddings for all dictionary signs.
 When a user submits a query video, the system compares the input embeddings with those of the dictionary entries using Euclidean distance.
 Tests on a [proof-of-concept Flemish Sign Language dictionary](https://github.com/m-decoster/VGT-SL-Dictionary) show that the system can successfully retrieve a limited vocabulary of signs, including some not in the training set.
-<!-- TODO: add VGT Corpus (dataset:herreweghe2015VGTCorpus) to list of datasets -->
 
-<!-- TODO: Sign language video retrieval with free-form textual queries was the only other paper that Cheng2023CiCoSignLanguageRetrieval compared with. -->
-
-@Cheng2023CiCoSignLanguageRetrieval introduce a video-to-text (V2T) and text-to-video (t2V) retrieval method based on cross-lingual contrastive learning.
-Using a "domain-agnostic" I3D encoder pretrained on large-scale sign datasets [@Varol2021ReadAndAttend] they generate pseudo-labels on target datasets and finetune a "domain-aware" encoder.
-Combining the two encoders they then pre-extract features from sign language videos.
-They then use cross-lingual contrastive learning [@Radford2021LearningTV] in order to contrast feature/text pairs, mapping them to a shared embedding space.
+@Cheng2023CiCoSignLanguageRetrieval introduce a video-to-text and text-to-video retrieval method based on cross-lingual contrastive learning.
+Inspired by previous work in transfer learning from sign-spotting/segmenting models [jui-etal-2022-machine;Duarte2022SignVideoRetrivalWithTextQueries], they adopt a "domain-agnostic" I3D encoder pretrained on large-scale sign language datasets for the sign-spotting task[@Varol2021ReadAndAttend].
+Then on target datasets with continuous signing videos, they use that sign-spotter model with a sliding window to find high-confidence predictions.
+Those predictions then are used to finetune a "domain-aware" sign-spotting encoder for the target dataset.
+Combining the two encoders, they pre-extract features from sign language videos.
+Cross-lingual contrastive learning [@Radford2021LearningTV] is then used in order to contrast feature/text pairs, mapping them to a shared embedding space.
 Embeddings of matched pairs are pulled together and non-matched pairs pushed apart.
-They evaluate on How2Sign [@dataset:duarte2020how2sign] and RWTH-PHOENIX-Weather 2014T dataset [@cihan2018neural], improving by a substantial portion over the previous state of the art method [@Duarte2022SignVideoRetrivalWithTextQueries].
+They evaluate on the How2Sign [@dataset:duarte2020how2sign] and RWTH-PHOENIX-Weather 2014T datasets [@cihan2018neural], improving substantially over the previous state of the art method [@Duarte2022SignVideoRetrivalWithTextQueries].
+In addition, they provide baseline retrieval results for the CSL-Daily dataset [@dataset:Zhou2021_SignBackTranslation_CSLDaily].
 
-<!-- TODO: add BSL-1K dataset, cited in Cheng2023CiCoSignLanguageRetrieval. https://github.com/gulvarol/bsl1k -->
+<!-- TODO: tie in with Automatic Dense Annotation of Large-Vocabulary Sign Language Videos, mentioned in video-to-gloss? Also uses Pseudo-labeling -->
 
 ### Fingerspelling
 

--- a/src/index.md
+++ b/src/index.md
@@ -921,11 +921,12 @@ When a user submits a query video, the system compares the input embeddings with
 Tests on a [proof-of-concept Flemish Sign Language dictionary](https://github.com/m-decoster/VGT-SL-Dictionary) show that the system can successfully retrieve a limited vocabulary of signs, including some not in the training set.
 
 @Cheng2023CiCoSignLanguageRetrieval introduce a video-to-text and text-to-video retrieval method using cross-lingual contrastive learning.
-Inspired by transfer learning from sign-spotting/segmenting models [@jui-etal-2022-machine;@Duarte2022SignVideoRetrivalWithTextQueries], the authors employ a domain-agnostic I3D encoder, pretrained on large-scale sign language datasets  for the sign-spotting task [@Varol2021ReadAndAttend].
+Inspired by transfer learning from sign-spotting/segmentation models [@jui-etal-2022-machine;@Duarte2022SignVideoRetrivalWithTextQueries], the authors employ a "domain-agnostic" I3D encoder, pretrained on large-scale sign language datasets for the sign-spotting task [@Varol2021ReadAndAttend].
 On target datasets with continuous signing videos, they use this model with a sliding window to identify high confidence predictions, which are then used to finetune a "domain-aware" sign-spotting encoder.
-The combined encoders pre-extract features from sign language videos.
-Cross-lingual contrastive learning [@Radford2021LearningTV] is applied to align feature-text pairs within a shared embedding space.
-Evaluations on How2Sign [@dataset:duarte2020how2sign] and RWTH-PHOENIX-Weather 2014T datasets [@cihan2018neural] demonstrate significant improvment over the previous state of the art method [@Duarte2022SignVideoRetrivalWithTextQueries].
+The two encoders each pre-extract features from videos, which are then fused via a weighted sum.
+Cross-lingual contrastive learning [@Radford2021LearningTV] is then applied to align the extracted features with paired texts within a shared embedding space.
+This allows the calculation of similarity scores between text and video embeddings, and thus retrieval in either direction.
+Evaluations on How2Sign [@dataset:duarte2020how2sign] and RWTH-PHOENIX-Weather 2014T datasets [@cihan2018neural] demonstrate  improvment over the previous state of the art method [@Duarte2022SignVideoRetrivalWithTextQueries].
 Baseline retrieval results are also provided for the CSL-Daily dataset [@dataset:Zhou2021_SignBackTranslation_CSLDaily].
 
 <!-- TODO: tie in with Automatic Dense Annotation of Large-Vocabulary Sign Language Videos, mentioned in video-to-gloss? Also uses Pseudo-labeling -->

--- a/src/index.md
+++ b/src/index.md
@@ -902,8 +902,12 @@ TODO
 
 Sign Language Retrieval is the task of finding a particular data item, given some input. In contrast to translation, generation or production tasks, there can exist a correct corresponding piece of data already, and the task is to find it out of many, if it exists.
 
-<!-- TODO: text-to-sign-video (T2V) section, sign-video-to-text (V2T) retrieval -->
-<!-- TODO: CiCo: Domain-Aware Sign Language Retrieval via Cross-Lingual Contrastive Learning -->
+<!-- TODO: text-to-sign-video (T2V) section, sign-video-to-text (V2T) retrieval? -->
+@athitsos2010LargeLexiconIndexingRetrieval present one of the early works in this task, using a method based on hand centroids and dynamic time warping to enable users to submit videos of a sign and thus query within the ASL Lexicon Video Dataset [@dataset:athitsos2008american].
+
+@Zhang2010RevisedEditDistanceSignVideoRetrieval provide another early method for video-based querying.
+They use classical image feature extraction methods to calculate movement trajectories.
+They then use modified string edit distances between these trajectories as a way to find similar videos.
 
 @costerQueryingSignLanguage2023 present a method to query sign language dictionaries using dense vector search.
 They pretrain a [Sign Language Recognition model](#pose-to-gloss) on a subset of the VGT corpus [@dataset:herreweghe2015VGTCorpus] to embed sign inputs.
@@ -912,19 +916,10 @@ When a user submits a query video, the system compares the input embeddings with
 Tests on a [proof-of-concept Flemish Sign Language dictionary](https://github.com/m-decoster/VGT-SL-Dictionary) show that the system can successfully retrieve a limited vocabulary of signs, including some not in the training set.
 <!-- TODO: add VGT Corpus (dataset:herreweghe2015VGTCorpus) to list of datasets -->
 
-@Cheng2023CiCoSignLanguageRetrieval introduce retrieval method based on cross-lingual contrastive learning. There's also something with pseudo-labeling. 
-They adapt the pretrained I3D encoder of @Varol2021ReadAndAttend as a "domain-agnostic sign encoder". 
-This lets them use transfer learning to help with data issues. 
-Sliding window on the encoder to pre-extract features helps with long context window. 
-There's a sign to word mapping. Section 3.3. talks about the cross-lingual constrastive learning. 
-Task: Text to Video retrieval, Video to Text retrieval, Contrastive Learning.
-Training in: video, text, "feature sequence". 
-Sign Encoder: Single-Ag, a domain-agnostic sign encoder based on @Varol2021ReadAndAttend, a I3D pretrained on BSL-1K. Single-Aw, a domain-aware sign encoder, identical arch but finetuned with pseudo-labeling. Weighted sum of the two.
-Training out: 
-Inference in: 
-Inference out: 
-Part of a lineage/family of approaches from the Chen folks. 
-"the thing to know about this is, they extend the CLIP idea to SL videos."
+
+<!-- TODO: CiCo: Domain-Aware Sign Language Retrieval via Cross-Lingual Contrastive Learning -->
+@Cheng2023CiCoSignLanguageRetrieval introduce a retrieval method based on cross-lingual contrastive learning.
+
 
 <!-- TODO: write about SPOT-ALIGN. Cheng2023CiCoSignLanguageRetrieval say retrival is "recently introduced... by SPOT-ALIGN" and cite Amanda Duarte, Samuel Albanie, Xavier Gir ́ o-i Nieto, and G ̈ ul Varol. Sign language video retrieval with free-form textual queries. -->
 <!-- TODO: add BSL-1K dataset, cited in Cheng2023CiCoSignLanguageRetrieval. https://github.com/gulvarol/bsl1k -->

--- a/src/index.md
+++ b/src/index.md
@@ -920,15 +920,13 @@ Once the encoder is trained, they use it to generate embeddings for all dictiona
 When a user submits a query video, the system compares the input embeddings with those of the dictionary entries using Euclidean distance.
 Tests on a [proof-of-concept Flemish Sign Language dictionary](https://github.com/m-decoster/VGT-SL-Dictionary) show that the system can successfully retrieve a limited vocabulary of signs, including some not in the training set.
 
-@Cheng2023CiCoSignLanguageRetrieval introduce a video-to-text and text-to-video retrieval method based on cross-lingual contrastive learning.
-Inspired by previous work in transfer learning from sign-spotting/segmenting models [jui-etal-2022-machine;Duarte2022SignVideoRetrivalWithTextQueries], they adopt a "domain-agnostic" I3D encoder pretrained on large-scale sign language datasets for the sign-spotting task[@Varol2021ReadAndAttend].
-Then on target datasets with continuous signing videos, they use that sign-spotter model with a sliding window to find high-confidence predictions.
-Those predictions then are used to finetune a "domain-aware" sign-spotting encoder for the target dataset.
-Combining the two encoders, they pre-extract features from sign language videos.
-Cross-lingual contrastive learning [@Radford2021LearningTV] is then used in order to contrast feature/text pairs, mapping them to a shared embedding space.
-Embeddings of matched pairs are pulled together and non-matched pairs pushed apart.
-They evaluate on the How2Sign [@dataset:duarte2020how2sign] and RWTH-PHOENIX-Weather 2014T datasets [@cihan2018neural], improving substantially over the previous state of the art method [@Duarte2022SignVideoRetrivalWithTextQueries].
-In addition, they provide baseline retrieval results for the CSL-Daily dataset [@dataset:Zhou2021_SignBackTranslation_CSLDaily].
+@Cheng2023CiCoSignLanguageRetrieval introduce a video-to-text and text-to-video retrieval method using cross-lingual contrastive learning.
+Inspired by transfer learning from sign-spotting/segmenting models [@jui-etal-2022-machine;@Duarte2022SignVideoRetrivalWithTextQueries], the authors employ a domain-agnostic I3D encoder, pretrained on large-scale sign language datasets  for the sign-spotting task [@Varol2021ReadAndAttend].
+On target datasets with continuous signing videos, they use this model with a sliding window to identify high confidence predictions, which are then used to finetune a "domain-aware" sign-spotting encoder.
+The combined encoders pre-extract features from sign language videos.
+Cross-lingual contrastive learning [@Radford2021LearningTV] is applied to align feature-text pairs within a shared embedding space.
+Evaluations on How2Sign [@dataset:duarte2020how2sign] and RWTH-PHOENIX-Weather 2014T datasets [@cihan2018neural] demonstrate significant improvment over the previous state of the art method [@Duarte2022SignVideoRetrivalWithTextQueries].
+Baseline retrieval results are also provided for the CSL-Daily dataset [@dataset:Zhou2021_SignBackTranslation_CSLDaily].
 
 <!-- TODO: tie in with Automatic Dense Annotation of Large-Vocabulary Sign Language Videos, mentioned in video-to-gloss? Also uses Pseudo-labeling -->
 

--- a/src/index.md
+++ b/src/index.md
@@ -912,6 +912,23 @@ When a user submits a query video, the system compares the input embeddings with
 Tests on a [proof-of-concept Flemish Sign Language dictionary](https://github.com/m-decoster/VGT-SL-Dictionary) show that the system can successfully retrieve a limited vocabulary of signs, including some not in the training set.
 <!-- TODO: add VGT Corpus (dataset:herreweghe2015VGTCorpus) to list of datasets -->
 
+@Cheng2023CiCoSignLanguageRetrieval introduce retrieval method based on cross-lingual contrastive learning. There's also something with pseudo-labeling. 
+They adapt the pretrained I3D encoder of @Varol2021ReadAndAttend as a "domain-agnostic sign encoder". 
+This lets them use transfer learning to help with data issues. 
+Sliding window on the encoder to pre-extract features helps with long context window. 
+There's a sign to word mapping. Section 3.3. talks about the cross-lingual constrastive learning. 
+Task: Text to Video retrieval, Video to Text retrieval, Contrastive Learning.
+Training in: video, text, "feature sequence". 
+Sign Encoder: Single-Ag, a domain-agnostic sign encoder based on @Varol2021ReadAndAttend, a I3D pretrained on BSL-1K. Single-Aw, a domain-aware sign encoder, identical arch but finetuned with pseudo-labeling. Weighted sum of the two.
+Training out: 
+Inference in: 
+Inference out: 
+Part of a lineage/family of approaches from the Chen folks. 
+"the thing to know about this is, they extend the CLIP idea to SL videos."
+
+<!-- TODO: write about SPOT-ALIGN. Cheng2023CiCoSignLanguageRetrieval say retrival is "recently introduced... by SPOT-ALIGN" and cite Amanda Duarte, Samuel Albanie, Xavier Gir ́ o-i Nieto, and G ̈ ul Varol. Sign language video retrieval with free-form textual queries. -->
+<!-- TODO: add BSL-1K dataset, cited in Cheng2023CiCoSignLanguageRetrieval. https://github.com/gulvarol/bsl1k -->
+
 ### Fingerspelling
 
 Fingerspelling is spelling a word letter-by-letter, borrowing from the spoken language alphabet [@battison1978lexical;@wilcox1992phonetics;@brentari2001language;@patrie2011fingerspelled].

--- a/src/index.md
+++ b/src/index.md
@@ -922,14 +922,12 @@ Tests on a [proof-of-concept Flemish Sign Language dictionary](https://github.co
 
 <!-- TODO: Sign language video retrieval with free-form textual queries was the only other paper that Cheng2023CiCoSignLanguageRetrieval compared with. -->
 
-<!-- TODO: CiCo: Domain-Aware Sign Language Retrieval via Cross-Lingual Contrastive Learning -->
 @Cheng2023CiCoSignLanguageRetrieval introduce a video-to-text (V2T) and text-to-video (t2V) retrieval method based on cross-lingual contrastive learning.
 Using a "domain-agnostic" I3D encoder pretrained on large-scale sign datasets [@Varol2021ReadAndAttend] they generate pseudo-labels on target datasets and finetune a "domain-aware" encoder.
 Combining the two encoders they then pre-extract features from sign language videos.
-They then use cross-lingual contrastive learning [@Radford2021LearningTV] in order to contrast feature/text pairs, mapping them to a shared embedding space. 
+They then use cross-lingual contrastive learning [@Radford2021LearningTV] in order to contrast feature/text pairs, mapping them to a shared embedding space.
 Embeddings of matched pairs are pulled together and non-matched pairs pushed apart.
 They evaluate on How2Sign [@dataset:duarte2020how2sign] and RWTH-PHOENIX-Weather 2014T dataset [@cihan2018neural], improving by a substantial portion over the previous state of the art method [@Duarte2022SignVideoRetrivalWithTextQueries].
-
 
 <!-- TODO: add BSL-1K dataset, cited in Cheng2023CiCoSignLanguageRetrieval. https://github.com/gulvarol/bsl1k -->
 

--- a/src/index.md
+++ b/src/index.md
@@ -902,12 +902,16 @@ TODO
 
 Sign Language Retrieval is the task of finding a particular data item, given some input. In contrast to translation, generation or production tasks, there can exist a correct corresponding piece of data already, and the task is to find it out of many, if it exists.
 
+Metrics used include retrieval at Rank K and (R@K, higher is better) and median rank (MedR, lower is better).
+
 <!-- TODO: text-to-sign-video (T2V) section, sign-video-to-text (V2T) retrieval? -->
 @athitsos2010LargeLexiconIndexingRetrieval present one of the early works in this task, using a method based on hand centroids and dynamic time warping to enable users to submit videos of a sign and thus query within the ASL Lexicon Video Dataset [@dataset:athitsos2008american].
 
 @Zhang2010RevisedEditDistanceSignVideoRetrieval provide another early method for video-based querying.
 They use classical image feature extraction methods to calculate movement trajectories.
 They then use modified string edit distances between these trajectories as a way to find similar videos.
+
+<!-- TODO: write about SPOT-ALIGN. Cheng2023CiCoSignLanguageRetrieval say retrival is "recently introduced... by SPOT-ALIGN" and cite Amanda Duarte, Samuel Albanie, Xavier Gir ́ o-i Nieto, and G ̈ ul Varol. Sign language video retrieval with free-form textual queries. -->
 
 @costerQueryingSignLanguage2023 present a method to query sign language dictionaries using dense vector search.
 They pretrain a [Sign Language Recognition model](#pose-to-gloss) on a subset of the VGT corpus [@dataset:herreweghe2015VGTCorpus] to embed sign inputs.
@@ -916,12 +920,17 @@ When a user submits a query video, the system compares the input embeddings with
 Tests on a [proof-of-concept Flemish Sign Language dictionary](https://github.com/m-decoster/VGT-SL-Dictionary) show that the system can successfully retrieve a limited vocabulary of signs, including some not in the training set.
 <!-- TODO: add VGT Corpus (dataset:herreweghe2015VGTCorpus) to list of datasets -->
 
+<!-- TODO: Sign language video retrieval with free-form textual queries was the only other paper that Cheng2023CiCoSignLanguageRetrieval compared with. -->
 
 <!-- TODO: CiCo: Domain-Aware Sign Language Retrieval via Cross-Lingual Contrastive Learning -->
-@Cheng2023CiCoSignLanguageRetrieval introduce a retrieval method based on cross-lingual contrastive learning.
+@Cheng2023CiCoSignLanguageRetrieval introduce a video-to-text (V2T) and text-to-video (t2V) retrieval method based on cross-lingual contrastive learning.
+Using a "domain-agnostic" I3D encoder pretrained on large-scale sign datasets [@Varol2021ReadAndAttend] they generate pseudo-labels on target datasets and finetune a "domain-aware" encoder.
+Combining the two encoders they then pre-extract features from sign language videos.
+They then use cross-lingual contrastive learning [@Radford2021LearningTV] in order to contrast feature/text pairs, mapping them to a shared embedding space. 
+Embeddings of matched pairs are pulled together and non-matched pairs pushed apart.
+They evaluate on How2Sign [@dataset:duarte2020how2sign] and RWTH-PHOENIX-Weather 2014T dataset [@cihan2018neural], improving by a substantial portion over the previous state of the art method [@Duarte2022SignVideoRetrivalWithTextQueries].
 
 
-<!-- TODO: write about SPOT-ALIGN. Cheng2023CiCoSignLanguageRetrieval say retrival is "recently introduced... by SPOT-ALIGN" and cite Amanda Duarte, Samuel Albanie, Xavier Gir ́ o-i Nieto, and G ̈ ul Varol. Sign language video retrieval with free-form textual queries. -->
 <!-- TODO: add BSL-1K dataset, cited in Cheng2023CiCoSignLanguageRetrieval. https://github.com/gulvarol/bsl1k -->
 
 ### Fingerspelling

--- a/src/index.md
+++ b/src/index.md
@@ -901,7 +901,7 @@ TODO
 
 ### Sign Language Retrieval
 
-Sign Language Retrieval is the task of finding a particular data item, given some input. In contrast to translation, generation or production tasks, there can exist a correct corresponding piece of data already, and the task is to find it out of many, if it exists. Metrics used include retrieval at Rank K and (R@K, higher is better) and median rank (MedR, lower is better).
+Sign Language Retrieval is the task of finding a particular data item, given some input. In contrast to translation, generation or production tasks, there can exist a correct corresponding piece of data already, and the task is to find it out of many, if it exists. Metrics used include retrieval at Rank K (R@K, higher is better) and median rank (MedR, lower is better).
 
 <!-- TODO: text-to-sign-video (T2V) section, sign-video-to-text (V2T) retrieval? -->
 @athitsos2010LargeLexiconIndexingRetrieval present one of the early works on this task, using a method based on hand centroids and dynamic time warping to enable users to submit videos of a sign and thus query within the ASL Lexicon Video Dataset [@dataset:athitsos2008american].

--- a/src/references.bib
+++ b/src/references.bib
@@ -3282,7 +3282,7 @@ author = {Oscar Koller and Jens Forster and Hermann Ney}
 @inproceedings{Cheng2023CiCoSignLanguageRetrieval,
   author={Cheng, Yiting and Wei, Fangyun and Bao, Jianmin and Chen, Dong and Zhang, Wenqiang},
   booktitle={2023 IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)}, 
-  title={CiCo: Domain-Aware Sign Language Retrieval via Cross-Lingual Contrastive Learning}, 
+  title={{CiCo}: Domain-Aware Sign Language Retrieval via Cross-Lingual Contrastive Learning}, 
   year={2023},
   doi={10.1109/CVPR52729.2023.01823}
 }

--- a/src/references.bib
+++ b/src/references.bib
@@ -3158,3 +3158,12 @@ Parikh, Ankur},
   year={2023},
   doi={10.1109/CVPR52729.2023.01823}
 }
+
+
+@inproceedings{Varol2021ReadAndAttend,
+  author={Varol, Gül and Momeni, Liliane and Albanie, Samuel and Afouras, Triantafyllos and Zisserman, Andrew},
+  booktitle={2021 IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)}, 
+  title={Read and Attend: Temporal Localisation in Sign Language Videos}, 
+  year={2021},
+  doi={10.1109/CVPR46437.2021.01658}
+}

--- a/src/references.bib
+++ b/src/references.bib
@@ -3150,3 +3150,11 @@ Parikh, Ankur},
  url = {https://aclanthology.org/2020.acl-main.704},
  year = {2020}
 }
+
+@inproceedings{Cheng2023CiCoSignLanguageRetrieval,
+  author={Cheng, Yiting and Wei, Fangyun and Bao, Jianmin and Chen, Dong and Zhang, Wenqiang},
+  booktitle={2023 IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)}, 
+  title={CiCo: Domain-Aware Sign Language Retrieval via Cross-Lingual Contrastive Learning}, 
+  year={2023},
+  doi={10.1109/CVPR52729.2023.01823}
+}

--- a/src/references.bib
+++ b/src/references.bib
@@ -3351,7 +3351,7 @@ Language Recognition},
     pages = "94--101"
 }
 
-@INPROCEEDINGS{dataset:Zhou2021_SignBackTranslation_CSLDaily,
+@inproceedings{dataset:Zhou2021_SignBackTranslation_CSLDaily,
   author={Zhou, Hao and Zhou, Wengang and Qi, Weizhen and Pu, Junfu and Li, Houqiang},
   booktitle={2021 IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)}, 
   title={Improving Sign Language Translation with Monolingual Data by Sign Back-Translation}, 

--- a/src/references.bib
+++ b/src/references.bib
@@ -357,6 +357,23 @@ American Sign Language},
  year = {2008}
 }
 
+@inproceedings{athitsos2010LargeLexiconIndexingRetrieval,
+  author    = {Athitsos, Vassilis and Neidle, Carol and Sclaroff, Stan and Nash, Joan and Stefan, Alexandra and Thangali, Ashwin and Wang, Haijing and Yuan, Quan},
+  title     = {Large Lexicon Project: {American} {Sign} {Language} Video Corpus and Sign Language Indexing/Retrieval Algorithms},
+  pages     = {11--14},
+  editor    = {Dreuw, Philippe and Efthimiou, Eleni and Hanke, Thomas and Johnston, Trevor and Mart{\'i}nez Ruiz, Gregorio and Schembri, Adam},
+  booktitle = {Proceedings of the {LREC2010} 4th Workshop on the Representation and Processing of Sign Languages: Corpora and Sign Language Technologies},
+  maintitle = {7th International Conference on Language Resources and Evaluation ({LREC} 2010)},
+  publisher = {{European Language Resources Association (ELRA)}},
+  address   = {Valletta, Malta},
+  day       = {22--23},
+  month     = may,
+  year      = {2010},
+  language  = {english},
+  url       = {https://www.sign-lang.uni-hamburg.de/lrec/pub/10022.pdf}
+}
+
+
 @inproceedings{dataset:dreuw2008benchmark,
  address = {Marrakech, Morocco},
  author = {Dreuw, Philippe  and
@@ -3166,4 +3183,14 @@ Parikh, Ankur},
   title={Read and Attend: Temporal Localisation in Sign Language Videos}, 
   year={2021},
   doi={10.1109/CVPR46437.2021.01658}
+}
+
+@INPROCEEDINGS{Zhang2010RevisedEditDistanceSignVideoRetrieval,
+  author={Shilin Zhang and Bo Zhang},
+  booktitle={2010 Second International Conference on Computational Intelligence and Natural Computing}, 
+  title={Using revised string edit distance to sign language video retrieval}, 
+  year={2010},
+  volume={1},
+  pages={45-49},
+  doi={10.1109/CINC.2010.5643895}
 }

--- a/src/references.bib
+++ b/src/references.bib
@@ -3330,3 +3330,26 @@ author = {Oscar Koller and Jens Forster and Hermann Ney}
   pages={14074-14084},
   doi={10.1109/CVPR52688.2022.01370}
 }
+
+@inproceedings{jui-etal-2022-machine,
+    title = "A Machine Learning-based Segmentation Approach for Measuring Similarity between Sign Languages",
+    author = "Jui, Tonni Das  and
+      Bejarano, Gissella  and
+      Rivas, Pablo",
+    booktitle = "Proceedings of the LREC2022 10th Workshop on the Representation and Processing of Sign Languages: Multilingual Sign Language Resources",
+    month = jun,
+    year = "2022",
+    address = "Marseille, France",
+    publisher = "European Language Resources Association",
+    url = "https://aclanthology.org/2022.signlang-1.15",
+    pages = "94--101"
+}
+
+@INPROCEEDINGS{dataset:Zhou2021_SignBackTranslation_CSLDaily,
+  author={Zhou, Hao and Zhou, Wengang and Qi, Weizhen and Pu, Junfu and Li, Houqiang},
+  booktitle={2021 IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)}, 
+  title={Improving Sign Language Translation with Monolingual Data by Sign Back-Translation}, 
+  year={2021},
+  pages={1316-1325},
+  doi={10.1109/CVPR46437.2021.00137}
+}

--- a/src/references.bib
+++ b/src/references.bib
@@ -3185,7 +3185,7 @@ Parikh, Ankur},
   doi={10.1109/CVPR46437.2021.01658}
 }
 
-@INPROCEEDINGS{Zhang2010RevisedEditDistanceSignVideoRetrieval,
+@inproceedings{Zhang2010RevisedEditDistanceSignVideoRetrieval,
   author={Shilin Zhang and Bo Zhang},
   booktitle={2010 Second International Conference on Computational Intelligence and Natural Computing}, 
   title={Using revised string edit distance to sign language video retrieval}, 
@@ -3193,4 +3193,29 @@ Parikh, Ankur},
   volume={1},
   pages={45-49},
   doi={10.1109/CINC.2010.5643895}
+}
+
+@inproceedings{Radford2021LearningTV,
+  title = 	 {Learning Transferable Visual Models From Natural Language Supervision},
+  author =       {Radford, Alec and Kim, Jong Wook and Hallacy, Chris and Ramesh, Aditya and Goh, Gabriel and Agarwal, Sandhini and Sastry, Girish and Askell, Amanda and Mishkin, Pamela and Clark, Jack and Krueger, Gretchen and Sutskever, Ilya},
+  booktitle = 	 {Proceedings of the 38th International Conference on Machine Learning},
+  pages = 	 {8748--8763},
+  year = 	 {2021},
+  editor = 	 {Meila, Marina and Zhang, Tong},
+  volume = 	 {139},
+  series = 	 {Proceedings of Machine Learning Research},
+  month = 	 {18--24 Jul},
+  publisher =    {PMLR},
+  pdf = 	 {http://proceedings.mlr.press/v139/radford21a/radford21a.pdf},
+  url = 	 {https://proceedings.mlr.press/v139/radford21a.html}
+}
+
+
+@inproceedings{Duarte2022SignVideoRetrivalWithTextQueries,
+  author={Duarte, Amanda and Albanie, Samuel and Giró-I-Nieto, Xavier and Varol, Gül},
+  booktitle={2022 IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)}, 
+  title={Sign Language Video Retrieval with Free-Form Textual Queries}, 
+  year={2022},
+  pages={14074-14084},
+  doi={10.1109/CVPR52688.2022.01370}
 }


### PR DESCRIPTION
Paper: https://openaccess.thecvf.com/content/CVPR2023/html/Bao_CiCo_Domain-Aware_Sign_Language_Retrieval_via_Cross-Lingual_Contrastive_Learning_CVPR_2023_paper.html

Added a summary of the paper, as well as some of the works leading up to it. And also citations to a few related papers. 

https://github.com/cleong110/sign-language-processing.github.io/issues/16 my writing process. 

TODO still: 
- [x] another editing pass with ChatGPT-assistance for conciseness. 
- [ ] Code and models are available at: https://github.com/FangyunWei/SLRT, maybe add a link. 


