### PR TITLE
CDL: ChicagoFSWild loader name update

### DIFF
--- a/src/datasets/ChicagoFSWild.json
+++ b/src/datasets/ChicagoFSWild.json
@@ -10,7 +10,7 @@
     "video",
     "text:Fingerspelling"
   ],
-  "loader": "chicagofswild",
+  "loader": "chicago_fs_wild",
   "language": "American",
   "#items": 26,
   "#samples": "7,304 Sequences",

--- a/src/datasets/ChicagoFSWildPlus.json
+++ b/src/datasets/ChicagoFSWildPlus.json
@@ -10,7 +10,7 @@
     "video",
     "text:Fingerspelling"
   ],
-  "loader": "chicagofswild",
+  "loader": "chicago_fs_wild",
   "language": "American",
   "#items": 26,
   "#samples": "55,232 Sequences",


### PR DESCRIPTION
chicagofswild ->chicago_fs_wild

#45 revealed that https://github.com/sign-language-processing/datasets/tree/master/sign_language_datasets/datasets/chicagofswild is invalid after an update to the loader name.

Correct link is now: https://github.com/sign-language-processing/datasets/tree/master/sign_language_datasets/datasets/chicago_fs_wild

