### PR TITLE
Adding "BEST: BERT Pre-training for Sign Language Recognition with Coupling Tokenization"

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -961,6 +961,19 @@ They found that for both forms of fingerspelling, on average, the longer the wor
 Furthermore, they found that less time is spent on middle letters on average, and the last letter is held on average for longer than the other letters in the word.
 Finally, they used this information to construct an animation system using letter pose interpolation and controlled the timing using a data-driven statistical model.
 
+### Pretraining and Representation-Learning
+
+<!-- BEST seems to be **B**ERT pre-training for **S**ign language recognition with coupling **T**okenization -->
+@Zhao2023BESTPretrainingSignLanguageRecognition introduce BEST, a pretraining method based on masked modeling of pose sequences using a coupled tokenization scheme.
+The method takes in pose triplet units (left hand, right hand, and upper-body with arms) as inputs.
+The pose for each part of the triplet is tokenized into discrete codes [@van_den_Oord_2017NeuralDiscreteRepresentationLearning].
+Then masked modeling is employed: any or all of the three parts may be masked, e.g. left hand, or right hand, or body+hand, or all of them...
+Unlike @hu2023SignBertPlus, they do not mask multi-frame sequnces ("clips") or sub-frame portions of a pose unit (joints).
+They validate their pretraining method isolated ISR (MS-ASL [@dataset:joze2018ms], WLASL [@dataset:li2020word], SLR500 [@huang2019attention3DCNNsSLR] and NMFs-CSL [@hu2021NMFAwareSLR]).
+They experiment with both pose-to-gloss and video-to-gloss via fusion with I3D [@carreira2017quo].
+Results on these datasets are SOTA compared to previous methods, and quite similar to those of SignBERT+ [@hu2023SignBertPlus]
+
+
 ## Annotation Tools
 
 ##### ELAN - EUDICO Linguistic Annotator

--- a/src/references.bib
+++ b/src/references.bib
@@ -3163,3 +3163,17 @@ Parikh, Ankur},
   month        = {Jun.},
   pages        = {3597-3605}
 }
+
+@inproceedings{van_den_Oord_2017NeuralDiscreteRepresentationLearning,
+author = {van den Oord, Aaron and Vinyals, Oriol and Kavukcuoglu, Koray},
+title = {Neural discrete representation learning},
+year = {2017},
+isbn = {9781510860964},
+publisher = {Curran Associates Inc.},
+address = {Red Hook, NY, USA},
+booktitle = {Proceedings of the 31st International Conference on Neural Information Processing Systems},
+pages = {6309–6318},
+numpages = {10},
+location = {Long Beach, California, USA},
+series = {NIPS'17}
+}

--- a/src/references.bib
+++ b/src/references.bib
@@ -3150,3 +3150,16 @@ Parikh, Ankur},
  url = {https://aclanthology.org/2020.acl-main.704},
  year = {2020}
 }
+
+@article{Zhao2023BESTPretrainingSignLanguageRecognition,
+  title        = {BEST: BERT Pre-training for Sign Language Recognition with Coupling Tokenization},
+  volume       = {37},
+  url          = {https://ojs.aaai.org/index.php/AAAI/article/view/25470},
+  doi          = {10.1609/aaai.v37i3.25470},
+  number       = {3},
+  journal      = {Proceedings of the AAAI Conference on Artificial Intelligence},
+  author       = {Zhao, Weichao and Hu, Hezhen and Zhou, Wengang and Shi, Jiaxin and Li, Houqiang},
+  year         = {2023},
+  month        = {Jun.},
+  pages        = {3597-3605}
+}


### PR DESCRIPTION

My notes on the process: https://github.com/cleong110/sign-language-processing.github.io/issues/19

A few things:
* No I don't know what BEST stands for, it's not called out explicitly in the paper but I _believe_ it is **B**ERT pre-training for **S**ign language recognition with coupling **T**okenization
* Might be good to double-check some of the stuff about coupling tokenization, I might not have understood it properly
* extremely similar in a number of ways to #54, to the point where I could not resist referencing it, and I think we need to merge that one first. Similar approach, evaluated on the same datasets with similar results. Even the table layouts are similar, with both of them calling their method "Ours +R" in the "from video" results. Neither one offers any code. 

TODO: 
- [ ]  rewrite for conciseness
- [ ] Merge #54 first
