### PR TITLE
CDL: add notes/docs about pandoc version requirement for `--citeproc`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ markdown: dst dst/index.html dst/style.css
 
 server: dst dst/style.css dst/index.md dst/sitemap.xml
 
+# CDL: this is where the bibliography @ citations are transformed, I believe, to things like (Someone 2024)
+# also, requires a newer version of pandoc, in order to use --citeproc
+# https://pandoc.org/releases.html#pandoc-2.11-2020-10-11 or greater,
+# which means that on Ubuntu you may need to go directly to the source repo and download/install the .deb
 dst/index.html: dst/index.md src/references.bib src/template/index.html dst/style.css
 	pandoc dst/index.md --template src/template/index.html -s --table-of-contents --bibliography=src/references.bib --citeproc --columns 1000 -H src/header.html -V lang=en -o $@
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The hosted github page is automatically built on push to master.
 
 To build the page locally, run `make`.
 
-Make sure you have [pandoc](https://pandoc.org/) installed.
+Make sure you have [pandoc](https://pandoc.org/) installed, version 2.11 or greater.
 
 ## Development
 To continuously build the page locally, listening to changes, run:


### PR DESCRIPTION
I'm not quite sure about this one. 

Basically, if you run 
```
apt install pandoc
```
on Ubuntu 22.04, or in Google Colab, then try to `make` the website it will complain that `--citeproc` is an "unrecognized" option. 