### PR TITLE
Fix/Update AUSLAN dataset

### DIFF
--- a/src/datasets/AUSLAN.json
+++ b/src/datasets/AUSLAN.json
@@ -1,15 +1,15 @@
 {
   "pub": {
     "name": "AUSLAN",
-    "year": 2010,
-    "publication": "dataset:johnston2010archive",
-    "url": "https://elar.soas.ac.uk/Collection/MPI55247"
+    "year": 2008,
+    "publication": "dataset:johnston2008archive",
+    "url": "http://hdl.handle.net/2196/00-0000-0000-0000-D7CF-8"
   },
-  "features": [],
+  "features": ["video", "gloss"],
   "language": "Australian",
   "#items": null,
   "#samples": "1,100 Videos",
   "#signers": 100,
-  "license": null,
-  "licenseUrl": null
+  "license": "Attribution",
+  "licenseUrl": "http://hdl.handle.net/2196/d8a991a5-d8cc-4f85-a5ff-c37279ebb625"
 }

--- a/src/index.md
+++ b/src/index.md
@@ -730,6 +730,11 @@ and so they have broken the dependency upon costly annotated gloss information i
 
 @shi-etal-2022-open introduce OpenASL, a large-scale American Sign Language (ASL) - English dataset collected from online video sites (e.g., YouTube), and then propose a set of techniques including sign search as a pretext task for pre-training and fusion of mouthing and handshape features to improve translation quality in the absence of glosses and in the presence of visually challenging data.
 
+In the First WMT Shared Task [@muller-etal-2022-findings], they found that about half of the participants chose to epresent sign language data as video frames using a visual feature extractor on the encoder side. 
+All submitted systems were sequence-to-sequence models based on Transformers [@vaswani2017attention].
+<!-- TODO: which? -->
+
+
 <!-- Really should put MMTLB here, a number of papers cite it including chen2022, which actually builds on it directly, cites it as a source for "mBART is good for SLT", etc. -->
 
 @chen2022TwoStreamNetworkSign present a two-stream network for sign language recognition (SLR) and translation (SLT), utilizing a dual visual encoder architecture to encode RGB video frames and pose keypoints in separate streams. 
@@ -791,6 +796,10 @@ They experimented both with GRU and various types of attention [@luong2015effect
 and showed similar performance, with the transformer underperforming on the validation set and overperforming on the test set, which consists of unseen signers.
 They experimented with various normalization schemes, mainly subtracting the mean and dividing by the standard deviation of every individual keypoint
 either concerning the entire frame or the relevant "object" (Body, Face, and Hand).
+
+In the First WMT Shared Task [@muller-etal-2022-findings], the baseline system [@mueller2022sign-sockeye-baselines] used pose inputs.
+In addition, they found that about half of the participants [@tarres-etal-2022-tackling;@hufe-avramidis-2022-experimental] chose to represent signed language data as poses.
+All submitted systems were sequence-to-sequence models based on Transformers [@vaswani2017attention].
 
 #### Text-to-Pose
 Text-to-Pose, also known as sign language production, is the task of producing a sequence of poses that adequately represent

--- a/src/references.bib
+++ b/src/references.bib
@@ -496,7 +496,7 @@ Kilian Q. Weinberger},
  year = {2013}
 }
 
-@inproceedings{dataset:johnston2010archive,
+@inproceedings{dataset:johnston2008archive,
  address = {The University of the Philippines Visayas Cebu College, Cebu City, Philippines},
  author = {Johnston, Trevor},
  booktitle = {Proceedings of the 22nd Pacific Asia Conference on Language, Information and Computation},

--- a/src/references.bib
+++ b/src/references.bib
@@ -2352,6 +2352,82 @@ Tissi, Katja},
  year = {2022}
 }
 
+@inproceedings{hufe-avramidis-2022-experimental,
+    title = "Experimental Machine Translation of the {S}wiss {G}erman Sign Language via 3{D} Augmentation of Body Keypoints",
+    author = "Hufe, Lorenz  and
+      Avramidis, Eleftherios",
+    booktitle = "Proceedings of the Seventh Conference on Machine Translation (WMT)",
+    month = dec,
+    year = "2022",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2022.wmt-1.95",
+    pages = "983--988"
+}
+
+@inproceedings{tarres-etal-2022-tackling,
+    title = "Tackling Low-Resourced Sign Language Translation: {UPC} at {WMT}-{SLT} 22",
+    author = "Tarres, Laia  and
+      G{\'a}llego, Gerard I.  and
+      Giro-i-nieto, Xavier  and
+      Torres, Jordi",
+    booktitle = "Proceedings of the Seventh Conference on Machine Translation (WMT)",
+    month = dec,
+    year = "2022",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2022.wmt-1.97",
+    pages = "994--1000"
+}
+
+@inproceedings{hamidullah-etal-2022-spatio,
+    title = "Spatio-temporal Sign Language Representation and Translation",
+    author = "Hamidullah, Yasser  and
+      Van Genabith, Josef  and
+      Espa{\~n}a-bonet, Cristina",
+    booktitle = "Proceedings of the Seventh Conference on Machine Translation (WMT)",
+    month = dec,
+    year = "2022",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2022.wmt-1.94",
+    pages = "977--982"
+}
+
+@inproceedings{dey-etal-2022-clean,
+    title = "Clean Text and Full-Body Transformer: {M}icrosoft{'}s Submission to the {WMT}22 Shared Task on Sign Language Translation",
+    author = "Dey, Subhadeep  and
+      Pal, Abhilash  and
+      Chaabani, Cyrine  and
+      Koller, Oscar",    
+    booktitle = "Proceedings of the Seventh Conference on Machine Translation (WMT)",
+    month = dec,
+    year = "2022",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2022.wmt-1.93",
+    pages = "969--976"
+}
+
+@inproceedings{shi-etal-2022-ttics,
+    title = "{TTIC}{'}s {WMT}-{SLT} 22 Sign Language Translation System",
+    author = "Shi, Bowen  and
+      Brentari, Diane  and
+      Shakhnarovich, Gregory  and
+      Livescu, Karen",
+    booktitle = "Proceedings of the Seventh Conference on Machine Translation (WMT)",
+    month = dec,
+    year = "2022",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2022.wmt-1.96",
+    pages = "989--993"
+}
+
+@misc{mueller2022sign-sockeye-baselines,
+    title={Sockeye baseline models for sign language translation},
+    author={M\"{u}ller, Mathias and Rios, Annette and Moryossef, Amit},
+    howpublished={\url{https://github.com/bricksdont/sign-sockeye-baselines}},
+    year={2022}
+}
+
+
+
 @inproceedings{shi-etal-2022-open,
  address = {Abu Dhabi, United Arab Emirates},
  author = {Shi, Bowen  and


### PR DESCRIPTION
Updated Features, License, and Citation. 

https://www.elararchive.org/dk0001 is the source. 

https://github.com/sign-language-processing/sign-language-processing.github.io/issues/81 has notes on how I came to these.