### PR TITLE
Adding features to BSL Corpus

### DIFF
--- a/src/datasets/BSL_Corpus.json
+++ b/src/datasets/BSL_Corpus.json
@@ -6,7 +6,7 @@
     "url": "https://bslcorpusproject.org/"
   },
   "loader": "bsl_corpus",
-  "features": [],
+  "features": ["video", "gloss:BSL", "text:English"],
   "language": "British",
   "#items": null,
   "#samples": "40,000 Lexical Items",


### PR DESCRIPTION
Based on https://bslcorpusproject.org/cava/:

>Lexical-level annotations and English translations of some of the conversation data from Bristol, Birmingham, London and Manchester and some narrative data from Belfast and Glasgow [are available for download in the form of ELAN annotation files](http://digital-collections.ucl.ac.uk/R/?local_base=BSLCP) (search for “eaf”), along with annotation guidelines explaining annotation procedures. English translations of all narrative data from all 8 regions (Bristol, Birmingham, London, Manchester, Cardiff, Newcastle, Belfast and Glasgow) are also available. More annotations, transcriptions and translations will be made available on this site periodically, after they have been completed and checked. See release notes for details of which files have been annotated and to what level of detail.