### PR TITLE
Deprecate CopyCat due to age and size and unavailability

### DIFF
--- a/src/datasets/CopyCat.json
+++ b/src/datasets/CopyCat.json
@@ -5,7 +5,8 @@
     "publication": "dataset:zafrulla2010novel",
     "url": "http://wearables.cc.gatech.edu/projects/copycat/"
   },
-  "features": [],
+  "status": "deprecated",
+  "features": ["video", "gloss"],
   "language": "American",
   "#items": 22,
   "#samples": "420 Phrases",


### PR DESCRIPTION
#91 must be merged first. 

Deprecation:
* Unavailable: https://wearables.cc.gatech.edu/projects/copycat/# shows no method to download the dataset.
* Small (420 phrases)
* Not commonly used/relevant.

Features:
https://ieeexplore.ieee.org/document/5543268 describes 420 phrases with glosses, accelerometer data, video.

![image](https://github.com/sign-language-processing/sign-language-processing.github.io/assets/122366389/f83b164c-1dae-4b65-a551-cb3021aea54f)
