### PR TITLE
Update and Deprecate Dicta-Sign

### DIFF
--- a/src/datasets/Dicta_Sign.json
+++ b/src/datasets/Dicta_Sign.json
@@ -5,8 +5,9 @@
     "publication": "dataset:matthes2012dicta",
     "url": "https://www.sign-lang.uni-hamburg.de/dicta-sign/portal/"
   },
+  "status": "deprecated",
   "loader": "dicta_sign",
-  "features": [],
+  "features": ["writing:HamNoSys", "gloss", "video"],
   "language": "Multilingual",
   "#items": null,
   "#samples": "6-8 Hours (/Participant)",

--- a/src/datasets/Dicta_Sign.json
+++ b/src/datasets/Dicta_Sign.json
@@ -5,7 +5,7 @@
     "publication": "dataset:matthes2012dicta",
     "url": "https://www.sign-lang.uni-hamburg.de/dicta-sign/portal/"
   },
-  "status": "deprecated",
+  "status": null,
   "loader": "dicta_sign",
   "features": ["writing:HamNoSys", "gloss", "video"],
   "language": "Multilingual",


### PR DESCRIPTION
#91 required first. 

Deprecation:
* https://www.sign-lang.uni-hamburg.de/dicta-sign/portal/index.html is in disrepair, and it is not clear that the data can actually be downloaded. There are many broken links. Videos do not consistently play.

Features:
* I have seen evidence of video, HamNoSys and glosses. 
* [However the sign_language_datasets loader](https://github.com/sign-language-processing/datasets/blob/master/sign_language_datasets/datasets/dicta_sign/dicta_sign.py) has also got pose and a few other features?  Not sure about this. 

