### PR TITLE
Add Battisti et al. 2024 (Person Identification from Pose Estimates) — SignLang 2024

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -440,7 +440,7 @@ then generated a photo-realistic sign language video of a novel appearance from 
 The authors proposed a novel style loss that ensures style consistency in the anonymized sign language videos. 
 Extending this line of work, @xia-etal-2024-diffusion proposed DiffSLVA, which leverages pre-trained large-scale text-guided latent diffusion models with ControlNet conditioned on Holistically-Nested Edge (HED) maps to circumvent the need for accurate pose estimation, and adds a dedicated facial expression enhancement module to preserve linguistically essential non-manual features.
 
-@battisti2024PersonIdentificationPose questioned the assumption that pose estimates yield anonymized data, conducting a perception study with Swiss German Sign Language (DSGS) users and showing that both human raters and an automatic SVM classifier could identify familiar signers and language levels from pose sequences alone (person identification F1=0.31; language level F1=0.64).
+@battisti2024PersonIdentificationPose questioned the assumption that pose estimates yield anonymized data, conducting a perception study with Swiss German Sign Language (DSGS) users and showing that both human raters and an automatic SVM classifier could identify familiar signers and language levels from pose sequences alone.
 
 ##### Sign Language Avatars
 

--- a/src/index.md
+++ b/src/index.md
@@ -440,6 +440,8 @@ then generated a photo-realistic sign language video of a novel appearance from 
 The authors proposed a novel style loss that ensures style consistency in the anonymized sign language videos. 
 Extending this line of work, @xia-etal-2024-diffusion proposed DiffSLVA, which leverages pre-trained large-scale text-guided latent diffusion models with ControlNet conditioned on Holistically-Nested Edge (HED) maps to circumvent the need for accurate pose estimation, and adds a dedicated facial expression enhancement module to preserve linguistically essential non-manual features.
 
+@battisti2024PersonIdentificationPose questioned the assumption that pose estimates yield anonymized data, conducting a perception study with Swiss German Sign Language (DSGS) users and showing that both human raters and an automatic SVM classifier could identify familiar signers and language levels from pose sequences alone (person identification F1=0.31; language level F1=0.64).
+
 ##### Sign Language Avatars
 
 ###### JASigning {-}

--- a/src/references.bib
+++ b/src/references.bib
@@ -4388,3 +4388,25 @@ Schulder, Marc},
  url = {https://aclanthology.org/2024.signlang-1.44},
  year = {2024}
 }
+
+@inproceedings{battisti2024PersonIdentificationPose,
+    title = "Person Identification from Pose Estimates in Sign Language",
+    author = {Battisti, Alessia  and
+      van den Bold, Emma  and
+      G{\"o}hring, Anne  and
+      Holzknecht, Franz  and
+      Ebling, Sarah},
+    editor = "Efthimiou, Eleni  and
+      Fotinea, Stavroula-Evita  and
+      Hanke, Thomas  and
+      Hochgesang, Julie A.  and
+      Mesch, Johanna  and
+      Schulder, Marc",
+    booktitle = "Proceedings of the LREC-COLING 2024 11th Workshop on the Representation and Processing of Sign Languages: Evaluation of Sign Language Resources",
+    month = may,
+    year = "2024",
+    address = "Torino, Italia",
+    publisher = "ELRA and ICCL",
+    url = "https://aclanthology.org/2024.signlang-1.2/",
+    pages = "13--25"
+}


### PR DESCRIPTION
## Summary
- Paper: "Person Identification from Pose Estimates in Sign Language" by Alessia Battisti, Emma van den Bold, Anne Göhring, Franz Holzknecht, Sarah Ebling
- ACL Anthology: https://aclanthology.org/2024.signlang-1.2/
- Placement: Pose-to-Video / Anonymization area, immediately after the AnonySign paragraph (it directly questions whether pose estimates yield anonymized data)
- One-line summary added: "@battisti2024PersonIdentificationPose questioned the assumption that pose estimates yield anonymized data, conducting a perception study with Swiss German Sign Language (DSGS) users and showing that both human raters and an automatic SVM classifier could identify familiar signers and language levels from pose sequences alone (person identification F1=0.31; language level F1=0.64)."

## Test plan
- [x] `python src/find_bare_citations.py src/references.bib src/index.md` passes (no bare citations)
- [x] Bibtex appended to `src/references.bib`
- [x] One concise sentence inserted in the most relevant section