### PR TITLE
Add Bono et al. 2024 (ELAN latency annotation for videoconferencing) — SignLang 2024

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1064,6 +1064,7 @@ An annotation can either be time-aligned to the media or refer to other existing
 The content of annotations consists of Unicode text, and annotation documents are stored in an XML format (EAF).
 ELAN is open source ([GPLv3](https://en.wikipedia.org/wiki/GNU_General_Public_License#Version_3)), and installation is [available](https://archive.mpi.nl/tla/elan/download) for Windows, macOS, and Linux.
 PyMPI [@pympi-1.69] allows for simple python interaction with Elan files.
+@bono-etal-2024-data extended ELAN-based transcription to videoconferencing dialogues by integrating per-participant latency tracks computed via cross-correlation of synchronised local recordings, enabling qualitative Conversation Analysis of greetings and turn-taking under network delay.
 
 ##### iLex
 [iLex](https://www.sign-lang.uni-hamburg.de/ilex/) [@hanke2002ilex] is a tool for sign language lexicography and corpus analysis, 

--- a/src/references.bib
+++ b/src/references.bib
@@ -4160,3 +4160,24 @@ Philipp Slusallek},
  title = {{{TEMOS}}: Generating Diverse Human Motions from Textual Descriptions},
  year = {2022}
 }
+
+@inproceedings{bono-etal-2024-data,
+    title = "Data Integration, Annotation, and Transcription Methods for Sign Language Dialogue with Latency in Videoconferencing",
+    author = "Bono, Mayumi  and
+      Okada, Tomohiro  and
+      Skobov, Victor  and
+      Adam, Robert",
+    editor = "Efthimiou, Eleni  and
+      Fotinea, Stavroula-Evita  and
+      Hanke, Thomas  and
+      Hochgesang, Julie A.  and
+      Mesch, Johanna  and
+      Schulder, Marc",
+    booktitle = "Proceedings of the LREC-COLING 2024 11th Workshop on the Representation and Processing of Sign Languages: Evaluation of Sign Language Resources",
+    month = may,
+    year = "2024",
+    address = "Torino, Italia",
+    publisher = "ELRA and ICCL",
+    url = "https://aclanthology.org/2024.signlang-1.3/",
+    pages = "26--35"
+}


### PR DESCRIPTION
## Summary
- Paper: "Data Integration, Annotation, and Transcription Methods for Sign Language Dialogue with Latency in Videoconferencing"
- Authors: Mayumi Bono, Tomohiro Okada, Victor Skobov, Robert Adam
- ACL Anthology: https://aclanthology.org/2024.signlang-1.3/
- Placement: Annotation Tools section, ELAN subsection (`src/index.md`)
- One-line summary: The authors integrated per-participant videoconferencing latency tracks into ELAN annotations (computed via SciPy cross-correlation of locally recorded Zoom videos) to support qualitative Conversation Analysis of Deaf signers' greetings and turn-taking under network delay.

## Test plan
- [x] `python src/find_bare_citations.py src/references.bib src/index.md` exits cleanly
- [x] Bibtex appended to `src/references.bib`
- [x] One concise sentence added in past tense at the most relevant location

🤖 Generated with [Claude Code](https://claude.com/claude-code)