### PR TITLE
Add Börstell (2024) on lexical variation in sign language corpora

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -218,6 +218,8 @@ Do not compare to scores produced with a different or unknown evaluation procedu
 - Given that glossing is corpus-specific, process glosses in a corpus-specific way, informed by transcription conventions.
 - Optimize gloss translation baselines with methods shown to be effective for low-resource MT.
 
+@borstell-2024-approach surveyed methods for measuring lexical frequency and variation in gloss-annotated sign language corpora, illustrating with Swedish Sign Language (STS) Corpus data how raw counts, relative frequencies, weighted log odds, and signer coverage each reveal different aspects of sociolinguistic variation while being shaped by Zipfian skew, elicitation topics, and annotation conventions.
+
 
 The following table additionally exemplifies the various representations for more isolated signs.
 For this example, we use SignWriting as the notation system.

--- a/src/references.bib
+++ b/src/references.bib
@@ -4207,3 +4207,21 @@ Schulder, Marc},
  url = {https://aclanthology.org/2024.signlang-1.4},
  year = {2024}
 }
+
+@inproceedings{borstell-2024-approach,
+    title = "How to Approach Lexical Variation in Sign Language Corpora",
+    author = {B{\"o}rstell, Carl},
+    editor = "Efthimiou, Eleni  and
+      Fotinea, Stavroula-Evita  and
+      Hanke, Thomas  and
+      Hochgesang, Julie A.  and
+      Mesch, Johanna  and
+      Schulder, Marc",
+    booktitle = "Proceedings of the LREC-COLING 2024 11th Workshop on the Representation and Processing of Sign Languages: Evaluation of Sign Language Resources",
+    month = may,
+    year = "2024",
+    address = "Torino, Italia",
+    publisher = "ELRA and ICCL",
+    url = "https://aclanthology.org/2024.signlang-1.5/",
+    pages = "46--53"
+}


### PR DESCRIPTION
## Summary
- Cite @borstell-2024-approach in the Glosses section, summarizing the paper's overview of methods (raw counts, relative frequencies, weighted log odds, signer coverage) for measuring lexical frequency and variation in gloss-annotated sign language corpora, with examples from the Swedish Sign Language (STS) Corpus.
- Append the corresponding BibTeX entry to `src/references.bib`.

## Test plan
- [x] `python src/find_bare_citations.py src/references.bib src/index.md` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)