### PR TITLE
Add SignLang 2024 reference: AZVD software editor (Filhol & von Ascheberg)

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -196,6 +196,7 @@ However, they remain a continuous, multidimensional representation that is not a
 represent signs as discrete visual features. Some systems are written linearly, and others use graphemes in two dimensions.
 While various universal [@writing:sutton1990lessons;@writing:prillwitz1990hamburg] and language-specific notation systems [@writing:stokoe1960sign;@writing:kakumasu1968urubu;@writing:bergman1977tecknad] have been proposed,
 no writing system has been adopted widely by any sign language community, and the lack of standards hinders the exchange and unification of resources and applications between projects.
+@filhol-von-ascheberg-2024-software introduced a web-based software editor for AZVD, a graphical sign language representation system that combines 2D symbols based on observed spontaneous productions with AZee expression mappings to keep diagrams synthesizable through avatar rendering.
 The figure above depicts two universal notation systems:
 SignWriting [@writing:sutton1990lessons], a two-dimensional pictographic system,
 and HamNoSys [@writing:prillwitz1990hamburg], a linear stream of graphemes designed to be machine-readable.

--- a/src/index.md
+++ b/src/index.md
@@ -196,7 +196,7 @@ However, they remain a continuous, multidimensional representation that is not a
 represent signs as discrete visual features. Some systems are written linearly, and others use graphemes in two dimensions.
 While various universal [@writing:sutton1990lessons;@writing:prillwitz1990hamburg] and language-specific notation systems [@writing:stokoe1960sign;@writing:kakumasu1968urubu;@writing:bergman1977tecknad] have been proposed,
 no writing system has been adopted widely by any sign language community, and the lack of standards hinders the exchange and unification of resources and applications between projects.
-AZVD is a graphical sign language representation system that combines 2D symbols based on observed spontaneous productions with AZee expression mappings to keep diagrams synthesizable through avatar rendering, for which @filhol-von-ascheberg-2024-software introduced a web-based software editor.
+AZVD [@filhol-von-ascheberg-2024-software] is a graphical sign language representation system that combines 2D symbols based on observed spontaneous productions with AZee expression mappings to keep diagrams synthesizable through avatar rendering.
 The figure above depicts two universal notation systems:
 SignWriting [@writing:sutton1990lessons], a two-dimensional pictographic system,
 and HamNoSys [@writing:prillwitz1990hamburg], a linear stream of graphemes designed to be machine-readable.
@@ -1109,6 +1109,9 @@ In Anvil, the annotator can see color-coded elements on multiple tracks in time 
 Some special features are cross-level links, non-temporal objects, timepoint tracks, coding agreement analysis, 
 3D viewing of motion capture data and a project tool for managing whole corpora of annotation files.
 Anvil installation is [available](http://www.anvil-software.de/download/index.html) for Windows, macOS, and Linux.
+
+##### AZVD Editor
+@filhol-von-ascheberg-2024-software introduced a web-based software editor for AZVD diagrams that produces AZee output for avatar rendering.
 
 ##### Other {-}
 @battisti-etal-2024-advancing presented a transcription and annotation scheme for continuous L1 and L2 data in Swiss German Sign Language (DSGS), introducing conventions for non-manual components and L2 learner errors, and outlined an initial inter-annotator agreement validation approach.

--- a/src/index.md
+++ b/src/index.md
@@ -196,7 +196,7 @@ However, they remain a continuous, multidimensional representation that is not a
 represent signs as discrete visual features. Some systems are written linearly, and others use graphemes in two dimensions.
 While various universal [@writing:sutton1990lessons;@writing:prillwitz1990hamburg] and language-specific notation systems [@writing:stokoe1960sign;@writing:kakumasu1968urubu;@writing:bergman1977tecknad] have been proposed,
 no writing system has been adopted widely by any sign language community, and the lack of standards hinders the exchange and unification of resources and applications between projects.
-@filhol-von-ascheberg-2024-software introduced a web-based software editor for AZVD, a graphical sign language representation system that combines 2D symbols based on observed spontaneous productions with AZee expression mappings to keep diagrams synthesizable through avatar rendering.
+AZVD is a graphical sign language representation system that combines 2D symbols based on observed spontaneous productions with AZee expression mappings to keep diagrams synthesizable through avatar rendering, for which @filhol-von-ascheberg-2024-software introduced a web-based software editor.
 The figure above depicts two universal notation systems:
 SignWriting [@writing:sutton1990lessons], a two-dimensional pictographic system,
 and HamNoSys [@writing:prillwitz1990hamburg], a linear stream of graphemes designed to be machine-readable.

--- a/src/references.bib
+++ b/src/references.bib
@@ -4599,3 +4599,22 @@ Schulder, Marc},
  url = {https://aclanthology.org/2024.signlang-1.29},
  year = {2024}
 }
+
+@inproceedings{filhol-von-ascheberg-2024-software,
+    title = "A software editor for the {AZVD} graphical Sign Language representation system",
+    author = "Filhol, Michael  and
+      von Ascheberg, Thomas",
+    editor = "Efthimiou, Eleni  and
+      Fotinea, Stavroula-Evita  and
+      Hanke, Thomas  and
+      Hochgesang, Julie A.  and
+      Mesch, Johanna  and
+      Schulder, Marc",
+    booktitle = "Proceedings of the LREC-COLING 2024 11th Workshop on the Representation and Processing of Sign Languages: Evaluation of Sign Language Resources",
+    month = may,
+    year = "2024",
+    address = "Torino, Italia",
+    publisher = "ELRA and ICCL",
+    url = "https://aclanthology.org/2024.signlang-1.8/",
+    pages = "77--85"
+}


### PR DESCRIPTION
## Summary
- Added a one-sentence reference to @filhol-von-ascheberg-2024-software in the "Written notation systems" section of `src/index.md`.
- The paper presents AZVD, a graphical sign language representation system (combining 2D symbols mapped to AZee expressions for synthesizability via avatars), and a web-based software editor prototype for AZVD content creation.
- Appended the matching BibTeX entry to `src/references.bib`.

## Test plan
- [x] `python src/find_bare_citations.py src/references.bib src/index.md` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)