### PR TITLE
Add Esselink et al. (2024) on inter-annotator agreement for NMMs

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1076,6 +1076,7 @@ The content of annotations consists of Unicode text, and annotation documents ar
 ELAN is open source ([GPLv3](https://en.wikipedia.org/wiki/GNU_General_Public_License#Version_3)), and installation is [available](https://archive.mpi.nl/tla/elan/download) for Windows, macOS, and Linux.
 PyMPI [@pympi-1.69] allows for simple python interaction with Elan files.
 @bono-etal-2024-data extended ELAN-based transcription to videoconferencing dialogues by integrating per-participant latency tracks computed via cross-correlation of synchronised local recordings, enabling qualitative Conversation Analysis of greetings and turn-taking under network delay.
+@esselink-etal-2024-evaluating evaluated inter-annotator agreement for non-manual markers in Sign Language of the Netherlands using complementary event-based and frame-based approaches on ELAN annotations, reporting low Cohen's kappa scores on several tiers and proposing concrete revisions to the annotation guidelines.
 
 ##### iLex
 [iLex](https://www.sign-lang.uni-hamburg.de/ilex/) [@hanke2002ilex] is a tool for sign language lexicography and corpus analysis, 

--- a/src/references.bib
+++ b/src/references.bib
@@ -4409,3 +4409,35 @@ Schulder, Marc},
  url = {https://aclanthology.org/2024.signlang-1.2},
  year = {2024}
 }
+
+    title = "Person Identification from Pose Estimates in Sign Language",
+    author = {Battisti, Alessia  and
+      van den Bold, Emma  and
+      G{\"o}hring, Anne  and
+      Holzknecht, Franz  and
+      Ebling, Sarah},
+}
+
+@inproceedings{esselink-etal-2024-evaluating,
+    title = "Evaluating Inter-Annotator Agreement for Non-Manual Markers in Sign Languages",
+    author = "Esselink, Lyke D.  and
+      Oomen, Marloes  and
+      Roelofsen, Floris",
+    editor = "Efthimiou, Eleni  and
+      Fotinea, Stavroula-Evita  and
+      Hanke, Thomas  and
+      Hochgesang, Julie A.  and
+      Mesch, Johanna  and
+      Schulder, Marc",
+    booktitle = "Proceedings of the LREC-COLING 2024 11th Workshop on the Representation and Processing of Sign Languages: Evaluation of Sign Language Resources",
+    month = may,
+    year = "2024",
+    address = "Torino, Italia",
+    publisher = "ELRA and ICCL",
+    url = "https://aclanthology.org/2024.signlang-1.2/",
+    pages = "13--25"
+}
+
+    url = "https://aclanthology.org/2024.signlang-1.7/",
+    pages = "66--76"
+}


### PR DESCRIPTION
## Summary
- Adds a citation to Esselink et al. (2024), "Evaluating Inter-Annotator Agreement for Non-Manual Markers in Sign Languages" (SignLang 2024), in the Annotation Tools section near the ELAN entry.
- Appends the corresponding BibTeX entry to `src/references.bib`.

The paper evaluates annotation guidelines for non-manual markers in Sign Language of the Netherlands (NGT) using event-based and frame-based inter-annotator agreement methods (Cohen's kappa), uncovering low agreement on several tiers and yielding concrete recommendations for refining the guidelines. Agreement scripts are released at https://doi.org/10.21942/uva.24080724.

## Test plan
- [x] `python src/find_bare_citations.py src/references.bib src/index.md` passes with no bare citations.

Generated with Claude Code