### PR TITLE
Add Matignon-LSF dataset paper (signlang 2024)

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1097,6 +1097,8 @@ Research papers which do not necessarily contribute new theory or architectures 
 
 @dataset:joshi-etal-2023-isltranslate introduce ISLTranslate, a large translation dataset for Indian Sign Language based on publicly available educational videos intended for hard-of-hearing children, which happen to contain both Indian Sign Language and English audio voiceover conveying the same content. They use a speech-to-text model to transcribe the audio content, which they later manually corrected with the help of accompanying books also containing the same content. They also use MediaPipe to extract pose features, and have a certified ISL signer validate a small portion of the sign-text pairs. They provide a baseline based on the architecture proposed in @camgoz2020sign, and provide code.
 
+@dataset:halbout-etal-2024-matignon presented Matignon-LSF, an open 39-hour corpus of live-interpreted Langue des Signes Française (LSF) compiled from weekly French government Council of Ministers debriefings, comprising 67 videos with aligned French audio, subtitles, and pre-computed I3D features.
+
 <!-- TODO: LSA-T aka dataset:dal2022lsa, they use AlphaPose "with the Halpe full-body keypoints format", a visualizer tool, and a baseline SLT model. Especially might be good to mention FiftyOne https://docs.voxel51.com/, "which
 provides useful features such as allowing to filter samples by label, video, playlist,
 or by the confidence score of the signer inference." -->

--- a/src/references.bib
+++ b/src/references.bib
@@ -4245,3 +4245,27 @@ Schulder, Marc},
  url = {https://aclanthology.org/2024.signlang-1.6},
  year = {2024}
 }
+
+@inproceedings{dataset:halbout-etal-2024-matignon,
+    title = "Matignon-{LSF}: a Large Corpus of Interpreted {F}rench {S}ign {L}anguage",
+    author = "Halbout, Julie  and
+      Fabre, Diandra  and
+      Ouakrim, Yanis  and
+      Lascar, Julie  and
+      Braffort, Annelies  and
+      Gouiff{\`e}s, Mich{\`e}le  and
+      Beautemps, Denis",
+    editor = "Efthimiou, Eleni  and
+      Fotinea, Stavroula-Evita  and
+      Hanke, Thomas  and
+      Hochgesang, Julie A.  and
+      Mesch, Johanna  and
+      Schulder, Marc",
+    booktitle = "Proceedings of the LREC-COLING 2024 11th Workshop on the Representation and Processing of Sign Languages: Evaluation of Sign Language Resources",
+    month = may,
+    year = "2024",
+    address = "Torino, Italia",
+    publisher = "ELRA and ICCL",
+    url = "https://aclanthology.org/2024.signlang-1.10/",
+    pages = "95--101"
+}


### PR DESCRIPTION
## Summary
- Adds a citation to the Matignon-LSF paper (Halbout et al., 2024) in the Dataset Papers section, summarizing this 39-hour openly-available corpus of live-interpreted French Sign Language (LSF) collected from French government Council of Ministers debriefings, with French audio, subtitles, and pre-computed I3D features.
- Appends the bibtex entry (with a `dataset:` prefix) to `src/references.bib`.

## Test plan
- [x] `python src/find_bare_citations.py src/references.bib src/index.md` reports no bare citations.

Generated with Claude Code