### PR TITLE
Add Imashev et al. 2024 K-RSL retrospective to Dataset Papers

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1099,6 +1099,8 @@ Research papers which do not necessarily contribute new theory or architectures 
 
 @dataset:halbout-etal-2024-matignon presented Matignon-LSF, an open 39-hour corpus of live-interpreted Langue des Signes Française (LSF) compiled from weekly French government Council of Ministers debriefings, comprising 67 videos with aligned French audio, subtitles, and pre-computed I3D features.
 
+@imashev-etal-2024-retrospective presented a decade-long retrospective of the Kazakh-Russian Sign Language (K-RSL) corpus, describing the progressive collection of healthcare videos and images, six-emotion sentences, phonological minimal pairs, statements and polar and content questions, and the K-RSL-173 sentence subset.
+
 <!-- TODO: LSA-T aka dataset:dal2022lsa, they use AlphaPose "with the Halpe full-body keypoints format", a visualizer tool, and a baseline SLT model. Especially might be good to mention FiftyOne https://docs.voxel51.com/, "which
 provides useful features such as allowing to filter samples by label, video, playlist,
 or by the confidence score of the signer inference." -->

--- a/src/references.bib
+++ b/src/references.bib
@@ -4268,3 +4268,28 @@ Schulder, Marc},
  url = {https://aclanthology.org/2024.signlang-1.10},
  year = {2024}
 }
+
+@inproceedings{imashev-etal-2024-retrospective,
+    title = "Retrospective of {K}azakh-{R}ussian {S}ign {L}anguage Corpus Formation",
+    author = "Imashev, Alfarabi  and
+      Kydyrbekova, Aigerim  and
+      Mukushev, Medet  and
+      Sandygulova, Anara  and
+      Islam, Shynggys  and
+      Israilov, Khassan  and
+      Makazhanov, Aibek  and
+      Yessenbayev, Zhandos",
+    editor = "Efthimiou, Eleni  and
+      Fotinea, Stavroula-Evita  and
+      Hanke, Thomas  and
+      Hochgesang, Julie A.  and
+      Mesch, Johanna  and
+      Schulder, Marc",
+    booktitle = "Proceedings of the LREC-COLING 2024 11th Workshop on the Representation and Processing of Sign Languages: Evaluation of Sign Language Resources",
+    month = may,
+    year = "2024",
+    address = "Torino, Italia",
+    publisher = "ELRA and ICCL",
+    url = "https://aclanthology.org/2024.signlang-1.12/",
+    pages = "111--122"
+}


### PR DESCRIPTION
## Summary
- Added a sentence under Resources -> Dataset Papers summarizing the decade-long retrospective of the Kazakh-Russian Sign Language (K-RSL) corpus by Imashev et al. (2024).
- Appended the corresponding bibtex entry (imashev-etal-2024-retrospective) to src/references.bib.

## Test plan
- [ ] Confirm the citation key resolves and renders correctly.
- [ ] Verify the new sentence reads well in the Dataset Papers subsection.

Generated with Claude Code