### PR TITLE
Add Khan et al. 2024 on ISL fingerspelling recognition with MHI and CNNs

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1017,8 +1017,6 @@ This dataset includes both the "careful" and "rapid" forms of fingerspelling col
 They trained a baseline model to take a sequence of images cropped around the signing hand and either use an autoregressive decoder or a CTC.
 They found that the CTC outperformed the autoregressive decoder model, but both achieved poor recognition rates (35-41% character level accuracy) compared to human performance (around 82%).
 
-@khan-etal-2024-investigating investigated isolated Irish Sign Language (ISL) fingerspelling recognition by converting clips from the ISL-HS hand-shape dataset into Motion History Images and training several pretrained CNN architectures (DenseNet, ResNet, Xception, and Inception variants) on the resulting frames, with DenseNet-121 achieving the highest classification accuracy of 90.38%.
-
 In follow-up work, @dataset:fs18iccv collected nearly an order-of-magnitude larger dataset and designed a new recognition model.
 Instead of detecting the signing hand, they detected the face and cropped a large area around it. 
 Then, they performed an iterative process of zooming in to the hand using visual attention to retain sufficient information in high resolution of the hand.
@@ -1027,6 +1025,8 @@ They showed that this method outperformed their original "hand crop" method by 4
 Looking through this dataset, we note that the videos in the dataset were taken from longer videos, and as they were cut, they did not retain the signing before the fingerspelling.
 This context relates to language modeling, where at first, one fingerspells a word carefully, and when repeating it, might fingerspell it rapidly, 
 but the interlocutors can infer they are fingerspelling the same word.
+
+@khan-etal-2024-investigating investigated isolated Irish Sign Language (ISL) fingerspelling recognition by converting clips from the ISL-HS hand-shape dataset into Motion History Images and training several pretrained CNN architectures (DenseNet, ResNet, Xception, and Inception variants) on the resulting frames, with DenseNet-121 achieving the highest classification accuracy of 90.38%.
 
 #### Production
 

--- a/src/index.md
+++ b/src/index.md
@@ -1017,6 +1017,8 @@ This dataset includes both the "careful" and "rapid" forms of fingerspelling col
 They trained a baseline model to take a sequence of images cropped around the signing hand and either use an autoregressive decoder or a CTC.
 They found that the CTC outperformed the autoregressive decoder model, but both achieved poor recognition rates (35-41% character level accuracy) compared to human performance (around 82%).
 
+@khan-etal-2024-investigating investigated isolated Irish Sign Language (ISL) fingerspelling recognition by converting clips from the ISL-HS hand-shape dataset into Motion History Images and training several pretrained CNN architectures (DenseNet, ResNet, Xception, and Inception variants) on the resulting frames, with DenseNet-121 achieving the highest classification accuracy of 90.38%.
+
 In follow-up work, @dataset:fs18iccv collected nearly an order-of-magnitude larger dataset and designed a new recognition model.
 Instead of detecting the signing hand, they detected the face and cropped a large area around it. 
 Then, they performed an iterative process of zooming in to the hand using visual attention to retain sufficient information in high resolution of the hand.

--- a/src/references.bib
+++ b/src/references.bib
@@ -4423,6 +4423,13 @@ Schulder, Marc},
     author = "Esselink, Lyke D.  and
       Oomen, Marloes  and
       Roelofsen, Floris",
+}
+
+@inproceedings{khan-etal-2024-investigating,
+    title = "Investigating Motion History Images and Convolutional Neural Networks for Isolated {I}rish {S}ign {L}anguage Fingerspelling Recognition",
+    author = "Khan, Sarmad  and
+      Murtagh, Irene  and
+      McLoughlin, Simon D.",
     editor = "Efthimiou, Eleni  and
       Fotinea, Stavroula-Evita  and
       Hanke, Thomas  and
@@ -4440,4 +4447,8 @@ Schulder, Marc},
 
     url = "https://aclanthology.org/2024.signlang-1.7/",
     pages = "66--76"
+}
+
+    url = "https://aclanthology.org/2024.signlang-1.15/",
+    pages = "140--146"
 }


### PR DESCRIPTION
## Summary
- Adds @khan-etal-2024-investigating to the Fingerspelling Recognition section, summarizing their use of Motion History Images and pretrained CNNs (DenseNet, ResNet, Xception, Inception) on the ISL-HS dataset for Irish Sign Language fingerspelling recognition.
- Defines the ISL acronym at first use within the section to disambiguate from Indian Sign Language usage elsewhere in the document.
- Appends the corresponding BibTeX entry to `src/references.bib`.

## Test plan
- [ ] Verify citation renders correctly in the Fingerspelling Recognition subsection.
- [ ] Confirm BibTeX entry is well-formed and references resolve.

Generated with [Claude Code](https://claude.com/claude-code)