### PR TITLE
Add Inoue et al. 2024 on JSL syllabic component classification

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -561,6 +561,7 @@ explicitly recognizes the role of phonology to achieve more accurate isolated si
 To allow additional predictions on phonological characteristics (such as handshape), 
 they combine the phonological annotations in ASL-LEX 2.0 [@dataset:sehyr2021asl] with signs in the WLASL 2000 ISLR benchmark [@dataset:li2020word]. 
 Interestingly, @tavella-etal-2022-wlasl construct a similar dataset aiming just for phonological property recognition in American Sign Language (ASL).
+@inoue-etal-2024-enhancing trained a Video-Keypoint Network (VKNet) to classify the location, movement, and handshape syllabic components of the dominant hand in Japanese Sign Language (JSL), and demonstrated that pre-training on the WLASL American Sign Language (ASL) dataset improved classification of the movement and handshape components when JSL training data was limited.
 
 #### Gloss-to-Pose
 Gloss-to-Pose, subsumed under the task of sign language production, is the task of producing a sequence of poses that adequately represent

--- a/src/references.bib
+++ b/src/references.bib
@@ -4279,6 +4279,14 @@ Schulder, Marc},
       Israilov, Khassan  and
       Makazhanov, Aibek  and
       Yessenbayev, Zhandos",
+}
+
+@inproceedings{inoue-etal-2024-enhancing,
+    title = "Enhancing Syllabic Component Classification in {J}apanese {S}ign {L}anguage by Pre-training on Non-{J}apanese {S}ign {L}anguage Data",
+    author = "Inoue, Jundai  and
+      Miwa, Makoto  and
+      Sasaki, Yutaka  and
+      Hara, Daisuke",
     editor = "Efthimiou, Eleni  and
       Fotinea, Stavroula-Evita  and
       Hanke, Thomas  and
@@ -4292,4 +4300,8 @@ Schulder, Marc},
     publisher = "ELRA and ICCL",
     url = "https://aclanthology.org/2024.signlang-1.12/",
     pages = "111--122"
+}
+
+    url = "https://aclanthology.org/2024.signlang-1.13/",
+    pages = "123--130"
 }


### PR DESCRIPTION
## Summary
- Adds a citation to Inoue et al. 2024 (SignLang 2024) in the section discussing phonological/syllabic property recognition.
- The paper trains a Video-Keypoint Network (VKNet) for syllabic component classification (location, movement, handshape) of the dominant hand in Japanese Sign Language (JSL), showing that pre-training on the WLASL ASL dataset improves classification of movement and handshape under limited JSL training data.
- Appends the corresponding bibtex entry to `src/references.bib`.

## Test plan
- [x] Citation key `inoue-etal-2024-enhancing` resolves (no bare citation reported by `find_bare_citations.py`).
- [x] Bibtex appended to `src/references.bib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)