### PR TITLE
Add Hall et al. 2024 on phonological transcription of CD-ASL

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1117,6 +1117,8 @@ Research papers which do not necessarily contribute new theory or architectures 
 
 @imashev-etal-2024-retrospective presented a decade-long retrospective of the Kazakh-Russian Sign Language (K-RSL) corpus, describing the progressive collection of healthcare videos and images, six-emotion sentences, phonological minimal pairs, statements and polar and content questions, and the K-RSL-173 sentence subset.
 
+@hall-etal-2024-phonological digitized and phonologically transcribed the Canadian Dictionary of ASL using the Sign Language Phonetic Annotator-Analyzer software, producing a searchable resource that captured handshape, movement, location, and relation parameters for roughly 2000 signs to enable phonologically based queries that paper-based dictionaries cannot support.
+
 <!-- TODO: LSA-T aka dataset:dal2022lsa, they use AlphaPose "with the Halpe full-body keypoints format", a visualizer tool, and a baseline SLT model. Especially might be good to mention FiftyOne https://docs.voxel51.com/, "which
 provides useful features such as allowing to filter samples by label, video, playlist,
 or by the confidence score of the signer inference." -->
@@ -1124,7 +1126,6 @@ or by the confidence score of the signer inference." -->
 ###### Bilingual dictionaries {-}
 for signed language [@dataset:mesch2012meaning;@fenlon2015building;@crasborn2016ngt;@dataset:gutierrez2016lse] map a spoken language word or short phrase to a signed language video.
 One notable dictionary, SpreadTheSign\footnote{\url{https://www.spreadthesign.com/}} is a parallel dictionary containing around 25,000 words with up to 42 different spoken-signed language pairs and more than 600,000 videos in total. Unfortunately, while dictionaries may help create lexical rules between languages, they do not demonstrate the grammar or the usage of signs in context.
-Going beyond gloss-based access, @hall-etal-2024-phonological digitized and phonologically transcribed the Canadian Dictionary of ASL using the Sign Language Phonetic Annotator-Analyzer software, producing a searchable resource that captured handshape, movement, location, and relation parameters for roughly 2000 signs to enable phonologically based queries that paper-based dictionaries cannot support.
 
 ###### Fingerspelling corpora {-}
 usually consist of videos of words borrowed from spoken languages that are signed letter-by-letter. They can be synthetically created [@dataset:dreuw2006modeling] or mined from online resources [@dataset:fs18slt;@dataset:fs18iccv]. However, they only capture one aspect of signed languages.

--- a/src/index.md
+++ b/src/index.md
@@ -1124,6 +1124,7 @@ or by the confidence score of the signer inference." -->
 ###### Bilingual dictionaries {-}
 for signed language [@dataset:mesch2012meaning;@fenlon2015building;@crasborn2016ngt;@dataset:gutierrez2016lse] map a spoken language word or short phrase to a signed language video.
 One notable dictionary, SpreadTheSign\footnote{\url{https://www.spreadthesign.com/}} is a parallel dictionary containing around 25,000 words with up to 42 different spoken-signed language pairs and more than 600,000 videos in total. Unfortunately, while dictionaries may help create lexical rules between languages, they do not demonstrate the grammar or the usage of signs in context.
+Going beyond gloss-based access, @hall-etal-2024-phonological digitized and phonologically transcribed the Canadian Dictionary of ASL using the Sign Language Phonetic Annotator-Analyzer software, producing a searchable resource that captured handshape, movement, location, and relation parameters for roughly 2000 signs to enable phonologically based queries that paper-based dictionaries cannot support.
 
 ###### Fingerspelling corpora {-}
 usually consist of videos of words borrowed from spoken languages that are signed letter-by-letter. They can be synthetically created [@dataset:dreuw2006modeling] or mined from online resources [@dataset:fs18slt;@dataset:fs18iccv]. However, they only capture one aspect of signed languages.

--- a/src/references.bib
+++ b/src/references.bib
@@ -4409,3 +4409,27 @@ Schulder, Marc},
  url = {https://aclanthology.org/2024.signlang-1.2},
  year = {2024}
 }
+
+@inproceedings{hall-etal-2024-phonological,
+    title = "Phonological Transcription of the {C}anadian Dictionary of {ASL} as a Language Resource",
+    author = "Hall, Kathleen Currie  and
+      Asthana, Anushka  and
+      Reid, Maggie  and
+      Gao, Yiran  and
+      Hobby, Grace  and
+      Tkachman, Oksana  and
+      Vesik, Kaili",
+    editor = "Efthimiou, Eleni  and
+      Fotinea, Stavroula-Evita  and
+      Hanke, Thomas  and
+      Hochgesang, Julie A.  and
+      Mesch, Johanna  and
+      Schulder, Marc",
+    booktitle = "Proceedings of the LREC-COLING 2024 11th Workshop on the Representation and Processing of Sign Languages: Evaluation of Sign Language Resources",
+    month = may,
+    year = "2024",
+    address = "Torino, Italia",
+    publisher = "ELRA and ICCL",
+    url = "https://aclanthology.org/2024.signlang-1.11/",
+    pages = "102--110"
+}


### PR DESCRIPTION
## Summary
- Adds citation to @hall-etal-2024-phonological in the Bilingual dictionaries section under Resources -> Dataset Papers.
- Describes the digitization and phonological transcription of the Canadian Dictionary of ASL using the SLP-AA software, with handshape, movement, location, and relation parameters coded for ~2000 signs.
- Appends the bibtex entry to src/references.bib.

## Test plan
- [x] Ran src/find_bare_citations.py to verify no bare citations.

Generated with Claude Code