### PR TITLE
Add Kimmelman et al. 2024 on headshake phonetics in NGT

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -119,6 +119,7 @@ Signed languages use multiple visual cues to convey different information simult
 For example, the signer may produce the sign for "cup" on one hand while simultaneously pointing to the actual cup with the other to express "that cup."
 Similarly to tone in spoken languages, the face and torso can convey additional affective information [@liddell2003grammar;@johnston2007australian].
 Facial expressions can modify adjectives, adverbs, and verbs; a head shake can negate a phrase or sentence; eye direction can help indicate referents.
+@kimmelman-etal-2024-headshakes apply OpenFace to corpus data from Sign Language of the Netherlands, showing that the linguistic function of a headshake (lexical, morphological, or prosodic) systematically affects its phonetic properties such as amplitude and peak velocity.
 
 ###### Referencing {-}
 The signer can introduce referents in discourse either by pointing to their actual locations in space or by assigning a region in the signing space to a non-present referent and by pointing to this region to refer to it [@rathmann2011featural;@schembri2018indicating].

--- a/src/references.bib
+++ b/src/references.bib
@@ -4287,6 +4287,13 @@ Schulder, Marc},
       Miwa, Makoto  and
       Sasaki, Yutaka  and
       Hara, Daisuke",
+}
+
+@inproceedings{kimmelman-etal-2024-headshakes,
+    title = "Headshakes in {NGT}: Relation between Phonetic Properties {\&} Linguistic Functions",
+    author = "Kimmelman, Vadim  and
+      Oomen, Marloes  and
+      Pfau, Roland",
     editor = "Efthimiou, Eleni  and
       Fotinea, Stavroula-Evita  and
       Hanke, Thomas  and
@@ -4304,4 +4311,8 @@ Schulder, Marc},
 
     url = "https://aclanthology.org/2024.signlang-1.13/",
     pages = "123--130"
+}
+
+    url = "https://aclanthology.org/2024.signlang-1.17/",
+    pages = "159--167"
 }


### PR DESCRIPTION
## Summary
- Cites Kimmelman, Oomen, and Pfau (2024), "Headshakes in NGT: Relation between Phonetic Properties & Linguistic Functions" (2024.signlang-1.17).
- Added one sentence in the simultaneity subsection (where head shake negation is already mentioned) summarizing their OpenFace-based finding that lexical, morphological, and prosodic headshakes differ in phonetic properties.
- Appended the BibTeX entry to src/references.bib.

## Test plan
- [ ] References render correctly in built site
- [ ] BibTeX entry parses without errors

Generated with Claude Code