### PR TITLE
Add Isard (2024) MY DGS -- ANNIS Query Wizard reference

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1091,6 +1091,9 @@ Some special features are cross-level links, non-temporal objects, timepoint tra
 3D viewing of motion capture data and a project tool for managing whole corpora of annotation files.
 Anvil installation is [available](http://www.anvil-software.de/download/index.html) for Windows, macOS, and Linux.
 
+##### MY DGS -- ANNIS Query Wizard
+@isard-2024-building presented a web-based Query Wizard that guided users through the construction of valid ANNIS Query Language expressions over the Public DGS Corpus [@dataset:hanke-etal-2020-extending] by composing context-sensitive blocks for annotation tiers, metadata, and inter-tier connections, which could then be opened directly in the MY DGS -- ANNIS portal.
+
 ## Resources
 
 ###### Dataset Papers

--- a/src/references.bib
+++ b/src/references.bib
@@ -4294,6 +4294,11 @@ Schulder, Marc},
     author = "Kimmelman, Vadim  and
       Oomen, Marloes  and
       Pfau, Roland",
+}
+
+@inproceedings{isard-2024-building,
+    title = "Building Your Query Step by Step: A Query Wizard for the {MY} {DGS} {--} {ANNIS} Portal of the {DGS} {C}orpus",
+    author = "Isard, Amy",
     editor = "Efthimiou, Eleni  and
       Fotinea, Stavroula-Evita  and
       Hanke, Thomas  and
@@ -4315,4 +4320,8 @@ Schulder, Marc},
 
     url = "https://aclanthology.org/2024.signlang-1.17/",
     pages = "159--167"
+}
+
+    url = "https://aclanthology.org/2024.signlang-1.14/",
+    pages = "131--139"
 }


### PR DESCRIPTION
## Summary
- Added a citation to @isard-2024-building, presenting a Query Wizard that helped users compose valid ANNIS Query Language queries over the Public DGS Corpus through context-sensitive building blocks.
- Placed under the Annotation Tools section, alongside iLex and other DGS Corpus-adjacent resources.

## Test plan
- [ ] Verify the citation key resolves correctly during build.
- [ ] Verify the new paragraph reads naturally in context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)