### PR TITLE
Add Lascar et al. 2024 on LSF annotation without pre-existing dictionary

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1162,6 +1162,8 @@ The Public DGS Corpus also saw multiple SignLang 2024 contributions: @konrad-eta
 
 @dataset:reverdy-etal-2024-stk introduce STK LSF, a one-hour bilingual French / French Sign Language (LSF) motion-capture corpus signed by a deaf signer covering targeted grammatical phenomena and three children's tales, used to drive a signing avatar for the SignToKids project.
 
+@lascar-etal-2024-annotation build a bilingual LSF/French lexicon from the subtitled Mediapi-RGB corpus without any pre-existing dictionary, combining weakly-supervised sign spotting with expert review and a supervised MLP classifier on Video Swin Transformer features to automatically annotate lexical units in continuous video.
+
 <!-- TODO: LSA-T aka dataset:dal2022lsa, they use AlphaPose "with the Halpe full-body keypoints format", a visualizer tool, and a baseline SLT model. Especially might be good to mention FiftyOne https://docs.voxel51.com/, "which
 provides useful features such as allowing to filter samples by label, video, playlist,
 or by the confidence score of the signer inference." -->

--- a/src/references.bib
+++ b/src/references.bib
@@ -4750,3 +4750,24 @@ Schulder, Marc},
  url = {https://aclanthology.org/2024.signlang-1.16},
  year = {2024}
 }
+
+@inproceedings{lascar-etal-2024-annotation,
+    title = "Annotation of {LSF} subtitled videos without a pre-existing dictionary",
+    author = "Lascar, Julie  and
+      Gouiff{\`e}s, Mich{\`e}le  and
+      Braffort, Annelies  and
+      Danet, Claire",
+    editor = "Efthimiou, Eleni  and
+      Fotinea, Stavroula-Evita  and
+      Hanke, Thomas  and
+      Hochgesang, Julie A.  and
+      Mesch, Johanna  and
+      Schulder, Marc",
+    booktitle = "Proceedings of the LREC-COLING 2024 11th Workshop on the Representation and Processing of Sign Languages: Evaluation of Sign Language Resources",
+    month = may,
+    year = "2024",
+    address = "Torino, Italia",
+    publisher = "ELRA and ICCL",
+    url = "https://aclanthology.org/2024.signlang-1.22/",
+    pages = "204--212"
+}


### PR DESCRIPTION
## Summary
- Cites @lascar-etal-2024-annotation (SignLang 2024) in the Automating Annotation subsection.
- The paper builds a bilingual LSF/French lexicon from the subtitled Mediapi-RGB corpus without any pre-existing dictionary, using weakly-supervised sign spotting (Video Swin Transformer features, BSL-pretrained), expert review, and a supervised MLP classifier for lexical-unit annotation in continuous LSF video.
- Adds the corresponding BibTeX entry to `src/references.bib`.

## Test plan
- [x] `python src/find_bare_citations.py src/references.bib src/index.md` reports no bare citations.

Generated with Claude Code