### PR TITLE
Cite Martínez-Guevara & Curiel (2024) on quantitative hand location analysis

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -110,7 +110,6 @@ palm orientation, placement, contact, path movement, local movement,
 as well as non-manual features including eye aperture, head movement, and torso positioning [@liddell1989american;@johnson2011toward;@brentari2011sign;@sandler2012phonological].
 Not all possible phonemes are realized in both signed and spoken languages, and inventories of two languages' phonemes/features may not overlap completely.
 Different languages are also subject to rules for the allowed combinations of features.
-Quantitative analyses of hand locations across BSL, NGT, and LSM further reveal that signers organize the signing space into a Zipfian spatial hierarchy, concentrating articulation in cohesive regions more systematically than non-linguistic gesturers [@martinez-guevara-curiel-2024-quantitative].
 
 ###### Simultaneity {-}
 Though an ASL sign takes about twice as long to produce than an English word,
@@ -1091,6 +1090,8 @@ Results on these datasets demonstrate state-of-the-art performance compared to p
 This sub-area covers experimental studies of sign language structure that use computational tools (corpus mining, computer-vision-assisted measurement, statistical modelling) to characterize specific linguistic phenomena, rather than to introduce new SLP methods.
 
 @gavrilescu-etal-2024-content compared corpus, elicitation, and fieldwork methods across Greek, French, and Swedish Sign Languages to characterize the distribution of wh-signs and their non-manual markers.
+
+@martinez-guevara-curiel-2024-quantitative analyse hand locations across BSL, NGT, and LSM and find that signers organize the signing space into a Zipfian spatial hierarchy, concentrating articulation in cohesive regions more systematically than non-linguistic gesturers.
 
 ## Annotation Tools
 

--- a/src/index.md
+++ b/src/index.md
@@ -110,6 +110,7 @@ palm orientation, placement, contact, path movement, local movement,
 as well as non-manual features including eye aperture, head movement, and torso positioning [@liddell1989american;@johnson2011toward;@brentari2011sign;@sandler2012phonological].
 Not all possible phonemes are realized in both signed and spoken languages, and inventories of two languages' phonemes/features may not overlap completely.
 Different languages are also subject to rules for the allowed combinations of features.
+Quantitative analyses of hand locations across BSL, NGT, and LSM further reveal that signers organize the signing space into a Zipfian spatial hierarchy, concentrating articulation in cohesive regions more systematically than non-linguistic gesturers [@martinez-guevara-curiel-2024-quantitative].
 
 ###### Simultaneity {-}
 Though an ASL sign takes about twice as long to produce than an English word,

--- a/src/references.bib
+++ b/src/references.bib
@@ -4757,6 +4757,12 @@ Schulder, Marc},
       Gouiff{\`e}s, Mich{\`e}le  and
       Braffort, Annelies  and
       Danet, Claire",
+}
+
+@inproceedings{martinez-guevara-curiel-2024-quantitative,
+    title = "Quantitative Analysis of Hand Locations in both Sign Language and Non-linguistic Gesture Videos",
+    author = "Mart{\'i}nez-Guevara, Niels  and
+      Curiel, Arturo",
     editor = "Efthimiou, Eleni  and
       Fotinea, Stavroula-Evita  and
       Hanke, Thomas  and
@@ -4770,4 +4776,8 @@ Schulder, Marc},
     publisher = "ELRA and ICCL",
     url = "https://aclanthology.org/2024.signlang-1.22/",
     pages = "204--212"
+}
+
+    url = "https://aclanthology.org/2024.signlang-1.25/",
+    pages = "225--234"
 }


### PR DESCRIPTION
## Summary
- Adds a citation in the Phonology section to Martínez-Guevara & Curiel (2024), "Quantitative Analysis of Hand Locations in both Sign Language and Non-linguistic Gesture Videos" (SignLang 2024).
- The paper shows that BSL, NGT, and LSM signers concentrate hand activity in a Zipfian spatial hierarchy more cohesive than non-linguistic gesturers' use of space.
- Appends the corresponding BibTeX entry to `references.bib`.

## Test plan
- [x] `python src/find_bare_citations.py src/references.bib src/index.md` reports no bare citations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)