### PR TITLE
Add Malaia et al. 2024 on radar-based sign language corpora

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -189,9 +189,12 @@ This technique has been extensively used in the field of computer vision to esti
 where the goal is to determine the spatial configuration of the body at each point in time. 
 Although high-quality pose estimation can be achieved using motion capture equipment, such methods are often expensive and intrusive. 
 As a result, estimating pose from videos has become the preferred method in recent years [@pose:pishchulin2012articulated;@pose:chen2017adversarial;@pose:cao2018openpose;@pose:alp2018densepose].
-As a non-intrusive alternative, @malaia-etal-2024-capturing argue that radar sensing can capture 3D articulator motion at high spatial and temporal resolution, preserving depth information lost in 2D video while only recording kinematic parameters and thus inherently protecting signer identity.
 Compared to video representations, accurate skeletal poses have a lower complexity and provide a semi-anonymized representation of the human body, while observing relatively low information loss. 
 However, they remain a continuous, multidimensional representation that is not adapted to most NLP models.
+
+###### Radar Sensing {-}
+captures 3D articulator motion through electromagnetic returns rather than visual frames, recording only kinematic parameters and thus inherently protecting signer identity.
+@malaia-etal-2024-capturing argue that radar can capture sign language motion at high spatial and temporal resolution, preserving depth information lost in 2D video as a non-intrusive alternative to motion capture.
 
 ###### Written notation systems {-}
 represent signs as discrete visual features. Some systems are written linearly, and others use graphemes in two dimensions.

--- a/src/index.md
+++ b/src/index.md
@@ -189,6 +189,7 @@ This technique has been extensively used in the field of computer vision to esti
 where the goal is to determine the spatial configuration of the body at each point in time. 
 Although high-quality pose estimation can be achieved using motion capture equipment, such methods are often expensive and intrusive. 
 As a result, estimating pose from videos has become the preferred method in recent years [@pose:pishchulin2012articulated;@pose:chen2017adversarial;@pose:cao2018openpose;@pose:alp2018densepose].
+As a non-intrusive alternative, @malaia-etal-2024-capturing argue that radar sensing can capture 3D articulator motion at high spatial and temporal resolution, preserving depth information lost in 2D video while only recording kinematic parameters and thus inherently protecting signer identity.
 Compared to video representations, accurate skeletal poses have a lower complexity and provide a semi-anonymized representation of the human body, while observing relatively low information loss. 
 However, they remain a continuous, multidimensional representation that is not adapted to most NLP models.
 

--- a/src/references.bib
+++ b/src/references.bib
@@ -4711,3 +4711,23 @@ Schulder, Marc},
  url = {https://aclanthology.org/2024.signlang-1.38},
  year = {2024}
 }
+
+@inproceedings{malaia-etal-2024-capturing,
+    title = "Capturing Motion: Using Radar to Build Better Sign Language Corpora",
+    author = "Malaia, Evie  and
+      Borneman, Joshua  and
+      Gurbuz, Sevgi",
+    editor = "Efthimiou, Eleni  and
+      Fotinea, Stavroula-Evita  and
+      Hanke, Thomas  and
+      Hochgesang, Julie A.  and
+      Mesch, Johanna  and
+      Schulder, Marc",
+    booktitle = "Proceedings of the LREC-COLING 2024 11th Workshop on the Representation and Processing of Sign Languages: Evaluation of Sign Language Resources",
+    month = may,
+    year = "2024",
+    address = "Torino, Italia",
+    publisher = "ELRA and ICCL",
+    url = "https://aclanthology.org/2024.signlang-1.23/",
+    pages = "213--218"
+}


### PR DESCRIPTION
## Summary
- Cites SignLang 2024 paper *Capturing Motion: Using Radar to Build Better Sign Language Corpora* (Malaia, Borneman, Gurbuz) as a non-intrusive, privacy-preserving alternative to motion capture and 2D video.
- Added to the Skeletal Poses representations section near the existing motion-capture mention.
- Adds the corresponding BibTeX entry to `src/references.bib`.

## Test plan
- [ ] Verify the citation renders correctly in the built site.
- [ ] Confirm BibTeX entry parses without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)