### PR TITLE
Add Malmberg et al. 2024 VQ-VAE sign representation paper

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1066,6 +1066,8 @@ The authors validate their pre-training method on isolated sign recognition (ISR
 Besides pose-to-gloss, they also experiment with video-to-gloss tasks via fusion with I3D [@carreira2017quo].
 Results on these datasets demonstrate state-of-the-art performance compared to previous methods and are comparable to those of SignBERT+ [@hu2023SignBertPlus].
 
+@malmberg-etal-2024-exploring train a VQ-VAE on pose-tracked Swedish Sign Language data to learn a codebook of motion primitives, comparing models trained on isolated signs, sentences, and a mixed set, and find that the sentence-trained model best reconstructs in-the-wild YouTube signing whose velocity profile is markedly faster than dictionary data.
+
 ## Annotation Tools
 
 ##### ELAN - EUDICO Linguistic Annotator

--- a/src/references.bib
+++ b/src/references.bib
@@ -4453,3 +4453,24 @@ Schulder, Marc},
  url = {https://aclanthology.org/2024.signlang-1.18},
  year = {2024}
 }
+
+@inproceedings{malmberg-etal-2024-exploring,
+    title = "Exploring Latent Sign Language Representations with Isolated Signs, Sentences and In-the-Wild Data",
+    author = "Malmberg, Fredrik  and
+      Klezovich, Anna  and
+      Mesch, Johanna  and
+      Beskow, Jonas",
+    editor = "Efthimiou, Eleni  and
+      Fotinea, Stavroula-Evita  and
+      Hanke, Thomas  and
+      Hochgesang, Julie A.  and
+      Mesch, Johanna  and
+      Schulder, Marc",
+    booktitle = "Proceedings of the LREC-COLING 2024 11th Workshop on the Representation and Processing of Sign Languages: Evaluation of Sign Language Resources",
+    month = may,
+    year = "2024",
+    address = "Torino, Italia",
+    publisher = "ELRA and ICCL",
+    url = "https://aclanthology.org/2024.signlang-1.24/",
+    pages = "219--224"
+}


### PR DESCRIPTION
## Summary
- Cite Malmberg et al. (SignLang 2024), which trains a VQ-VAE to learn a codebook of motion primitives from Swedish Sign Language data.
- Added to the "Pretraining and Representation-learning" section, summarizing the comparison between isolated-sign, sentence, and mixed VQ-VAE models on dictionary and in-the-wild YouTube data.
- Bibtex appended in src/references.bib.

## Test plan
- [ ] Build the site and confirm the new sentence renders with a valid citation link.
- [ ] Confirm references.bib still parses without duplicate keys.

Citation key: malmberg-etal-2024-exploring
Paper: https://aclanthology.org/2024.signlang-1.24/

Generated with Claude Code