### PR TITLE
Add Martinod & Filhol (2024) on LSF interrogation marking

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1082,6 +1082,7 @@ PyMPI [@pympi-1.69] allows for simple python interaction with Elan files.
 @bono-etal-2024-data extended ELAN-based transcription to videoconferencing dialogues by integrating per-participant latency tracks computed via cross-correlation of synchronised local recordings, enabling qualitative Conversation Analysis of greetings and turn-taking under network delay.
 @esselink-etal-2024-evaluating evaluated inter-annotator agreement for non-manual markers in Sign Language of the Netherlands using complementary event-based and frame-based approaches on ELAN annotations, reporting low Cohen's kappa scores on several tiers and proposing concrete revisions to the annotation guidelines.
 @kimmelman-etal-2024-nonmanual combine ELAN annotations with OpenFace-based head pose estimation to show that Balinese homesigners and their hearing interlocutors consistently mark polar questions with downward head pitch and other question types with upward pitch, demonstrating how computer vision tools can quantitatively support linguistic analysis of non-manual markers.
+@martinod-filhol-2024-formal performed a corpus-based AZee analysis of French Sign Language (LSF) and found that chin advancement, rather than eyebrow position, is the consistent marker of information requests, challenging the widely reported open- vs. closed-question eyebrow contrast.
 
 ##### iLex
 [iLex](https://www.sign-lang.uni-hamburg.de/ilex/) [@hanke2002ilex] is a tool for sign language lexicography and corpus analysis, 

--- a/src/references.bib
+++ b/src/references.bib
@@ -4496,3 +4496,33 @@ Schulder, Marc},
  url = {https://aclanthology.org/2024.signlang-1.32},
  year = {2024}
 }
+
+    title = "Exploring Latent Sign Language Representations with Isolated Signs, Sentences and In-the-Wild Data",
+    author = "Malmberg, Fredrik  and
+      Klezovich, Anna  and
+      Mesch, Johanna  and
+      Beskow, Jonas",
+}
+
+@inproceedings{martinod-filhol-2024-formal,
+    title = "Formal Representation of Interrogation in {F}rench {S}ign {L}anguage",
+    author = "Martinod, Emmanuella  and
+      Filhol, Michael",
+    editor = "Efthimiou, Eleni  and
+      Fotinea, Stavroula-Evita  and
+      Hanke, Thomas  and
+      Hochgesang, Julie A.  and
+      Mesch, Johanna  and
+      Schulder, Marc",
+    booktitle = "Proceedings of the LREC-COLING 2024 11th Workshop on the Representation and Processing of Sign Languages: Evaluation of Sign Language Resources",
+    month = may,
+    year = "2024",
+    address = "Torino, Italia",
+    publisher = "ELRA and ICCL",
+    url = "https://aclanthology.org/2024.signlang-1.24/",
+    pages = "219--224"
+}
+
+    url = "https://aclanthology.org/2024.signlang-1.26/",
+    pages = "235--243"
+}


### PR DESCRIPTION
## Summary
- Adds Martinod & Filhol (2024), "Formal Representation of Interrogation in French Sign Language" (SignLang 2024, ACL Anthology 2024.signlang-1.26).
- Cited in the Sign Language Linguistics Overview (Simultaneity / non-manual features) where facial cues are discussed.
- The paper applies the AZee formal framework to Dicta-Sign LSF corpus data and finds that chin advancement, not eyebrow position, is the invariant non-manual marker of information requests, challenging the open/closed-question eyebrow contrast widely reported in prior literature.

## Test plan
- [ ] Verify citation key `martinod-filhol-2024-formal` resolves in the rendered site.
- [ ] Confirm the new sentence in src/index.md reads naturally in context.

Generated with Claude Code