### PR TITLE
Add McDonald et al. (2024) multilingual PAULA synthesis citation

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -485,7 +485,8 @@ Additional improvements to PAULA focus on making the avatar more lifelike by rel
 refining hand shape transition, relaxation, and collision [@paula:baowidan2021improving], 
 implementing hierarchical phrase transitions [@paula:mcdonald2021natural], 
 creating more realistic facial muscle control [@paula:mcdonald2022novel], 
-and supporting geometric relocations [@paula:filhol2022representation].
+supporting geometric relocations [@paula:filhol2022representation], 
+and exploring multilingual synthesis by reusing AZee descriptions of classifier and depicting constructs across LSF, DGS, and GSL [@paula:mcdonald2024multilingual].
 
 ###### SiMAX [@SiMAX2020SignLanguage] {-}
 

--- a/src/references.bib
+++ b/src/references.bib
@@ -4508,6 +4508,14 @@ Schulder, Marc},
     title = "Formal Representation of Interrogation in {F}rench {S}ign {L}anguage",
     author = "Martinod, Emmanuella  and
       Filhol, Michael",
+}
+
+@inproceedings{paula:mcdonald2024multilingual,
+    title = "Multilingual Synthesis of Depictions through Structured Descriptions of Sign: An Initial Case Study",
+    author = "McDonald, John  and
+      Efthimiou, Eleni  and
+      Fotinea, Stavroula-Evita  and
+      Wolfe, Rosalee",
     editor = "Efthimiou, Eleni  and
       Fotinea, Stavroula-Evita  and
       Hanke, Thomas  and
@@ -4525,4 +4533,8 @@ Schulder, Marc},
 
     url = "https://aclanthology.org/2024.signlang-1.26/",
     pages = "235--243"
+}
+
+    url = "https://aclanthology.org/2024.signlang-1.27/",
+    pages = "244--253"
 }


### PR DESCRIPTION
## Summary
- Adds a citation to McDonald et al. (2024), "Multilingual Synthesis of Depictions through Structured Descriptions of Sign: An Initial Case Study" (SignLang 2024).
- Extends the PAULA section with one sentence noting the multilingual case study using AZee descriptions for classifier and depicting constructs across LSF, DGS, and GSL.
- Appends the corresponding BibTeX entry (`paula:mcdonald2024multilingual`) to `src/references.bib`.

## Test plan
- [ ] Verify the new citation key resolves in the rendered site.
- [ ] Confirm the PAULA paragraph still reads naturally with the added clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)