### PR TITLE
Add Miyazaki et al. 2024 (Gloss Pair Encoding) to Text-to-Gloss

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -725,6 +725,8 @@ complexity of the model.
 Testing their model on the RWTH-PHOENIX-Weather-2014T [@cihan2018neural], 
 they demonstrated that injecting this additional information results in better translation quality. 
 
+@miyazaki-etal-2024-sign propose Gloss Pair Encoding (GPE), a BPE-inspired tokenization that merges frequently co-occurring gloss pairs (e.g., "book"+"building" $\to$ "library") into single tokens to match granularity between spoken and signed languages, and show on a Japanese-JSL news corpus that combining GPE-augmented and original training data improves text-to-gloss translation while merging non-manual markers (head-nods, pointing) hurts performance.
+
 ---
 
 #### Video-to-Text

--- a/src/index.md
+++ b/src/index.md
@@ -725,7 +725,7 @@ complexity of the model.
 Testing their model on the RWTH-PHOENIX-Weather-2014T [@cihan2018neural], 
 they demonstrated that injecting this additional information results in better translation quality. 
 
-@miyazaki-etal-2024-sign propose Gloss Pair Encoding (GPE), a BPE-inspired tokenization that merges frequently co-occurring gloss pairs (e.g., "book"+"building" $\to$ "library") into single tokens to match granularity between spoken and signed languages, and show on a Japanese-JSL news corpus that combining GPE-augmented and original training data improves text-to-gloss translation while merging non-manual markers (head-nods, pointing) hurts performance.
+@miyazaki-etal-2024-sign propose Gloss Pair Encoding (GPE), a BPE-inspired tokenization that merges frequent gloss pairs into single tokens to better match granularity between spoken and signed languages, and show that combining GPE-augmented data with the original training data improves text-to-gloss translation on a Japanese-JSL corpus.
 
 ---
 

--- a/src/references.bib
+++ b/src/references.bib
@@ -4554,6 +4554,14 @@ Schulder, Marc},
       Hwang, Eui Jun  and
       Cho, Sukmin  and
       Park, Jong C.",
+}
+
+@inproceedings{miyazaki-etal-2024-sign,
+    title = "Sign Language Translation with Gloss Pair Encoding",
+    author = "Miyazaki, Taro  and
+      Tan, Sihan  and
+      Uchida, Tsubasa  and
+      Kaneko, Hiroyuki",
     editor = "Efthimiou, Eleni  and
       Fotinea, Stavroula-Evita  and
       Hanke, Thomas  and
@@ -4571,4 +4579,8 @@ Schulder, Marc},
 
     url = "https://aclanthology.org/2024.signlang-1.36/",
     pages = "323--334"
+}
+
+    url = "https://aclanthology.org/2024.signlang-1.29/",
+    pages = "262--268"
 }


### PR DESCRIPTION
## Summary
- Adds @miyazaki-etal-2024-sign (SignLang 2024, ID 2024.signlang-1.29) to the Text-to-Gloss section.
- Paper introduces Gloss Pair Encoding (GPE), a BPE-inspired method that merges frequent gloss pairs (e.g., "book"+"building" -> "library") into single tokens, evaluated on a Japanese-JSL news corpus with a Transformer encoder-decoder.
- Adds the corresponding BibTeX entry to references.bib.

## Test plan
- [ ] Citation key resolves correctly when the site builds.
- [ ] Sentence reads naturally within the Text-to-Gloss subsection.

Generated with Claude Code