### PR TITLE
Add SignCollect (Otterspeer et al., 2024) to Automating Annotation

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1131,6 +1131,9 @@ Anvil installation is [available](http://www.anvil-software.de/download/index.ht
 ##### AZVD Editor
 @filhol-von-ascheberg-2024-software introduced a web-based software editor for AZVD diagrams that produces AZee output for avatar rendering.
 
+##### SignCollect
+@otterspeer-etal-2024-signcollect introduce SignCollect, a 'touchless' multi-view recording pipeline using MediaPipe gesture recognition to let a lone signer capture lexical entries and publish them to Global Signbank without assisting staff.
+
 ##### Other {-}
 @battisti-etal-2024-advancing presented a transcription and annotation scheme for continuous L1 and L2 data in Swiss German Sign Language (DSGS), introducing conventions for non-manual components and L2 learner errors, and outlined an initial inter-annotator agreement validation approach.
 
@@ -1217,11 +1220,7 @@ Therefore, data collection often requires significant efforts and costs of on-si
 
 ###### Automating Annotation {-}
 One helpful research direction for collecting more data that enables the development of deployable SLP models is creating tools that can simplify or automate parts of the collection and annotation process. One of the most significant bottlenecks in obtaining more adequate signed language data is the time and scarcity of experts required to perform annotation. Therefore, tools that perform automatic parsing, detection of frame boundaries, extraction of articulatory features, suggestions for lexical annotations, and allow parts of the annotation process to be crowdsourced to non-experts, to name a few, have a high potential to facilitate and accelerate the availability of good data.
-<<<<<<< HEAD
 Targeting prosodic non-manual annotation specifically, @susman-kimmelman-2024-eye trained a CNN classifier of eye openness (open, in-between, closed) on French Sign Language data and combined it with rule-based temporal aggregation to detect linguistically defined eye blinks, outperforming an Eye Aspect Ratio (EAR) baseline computed from MediaPipe landmarks.
-=======
-In this direction, @otterspeer-etal-2024-signcollect introduce SignCollect, a 'touchless' multi-view recording pipeline using MediaPipe gesture recognition to let a lone signer capture 60--120 lexical entries per hour and publish them to Global Signbank without assisting staff.
->>>>>>> ee98625 (Add SignCollect (Otterspeer et al., 2024) to Automating Annotation)
 
 ### Practice Deaf Collaboration
 

--- a/src/index.md
+++ b/src/index.md
@@ -1128,14 +1128,11 @@ Some special features are cross-level links, non-temporal objects, timepoint tra
 3D viewing of motion capture data and a project tool for managing whole corpora of annotation files.
 Anvil installation is [available](http://www.anvil-software.de/download/index.html) for Windows, macOS, and Linux.
 
-##### AZVD Editor
-@filhol-von-ascheberg-2024-software introduced a web-based software editor for AZVD diagrams that produces AZee output for avatar rendering.
-
-##### SignCollect
-@otterspeer-etal-2024-signcollect introduce SignCollect, a 'touchless' multi-view recording pipeline using MediaPipe gesture recognition to let a lone signer capture lexical entries and publish them to Global Signbank without assisting staff.
-
 ##### Other {-}
-@battisti-etal-2024-advancing presented a transcription and annotation scheme for continuous L1 and L2 data in Swiss German Sign Language (DSGS), introducing conventions for non-manual components and L2 learner errors, and outlined an initial inter-annotator agreement validation approach.
+
+- @filhol-von-ascheberg-2024-software introduced a web-based software editor for AZVD diagrams that produces AZee output for avatar rendering.
+- @otterspeer-etal-2024-signcollect introduce SignCollect, a "touchless" multi-view recording pipeline using MediaPipe gesture recognition to let a lone signer capture lexical entries and publish them to Global Signbank without assisting staff.
+- @battisti-etal-2024-advancing presented a transcription and annotation scheme for continuous L1 and L2 data in Swiss German Sign Language (DSGS), introducing conventions for non-manual components and L2 learner errors, and outlined an initial inter-annotator agreement validation approach.
 
 ## Resources
 

--- a/src/index.md
+++ b/src/index.md
@@ -1217,7 +1217,11 @@ Therefore, data collection often requires significant efforts and costs of on-si
 
 ###### Automating Annotation {-}
 One helpful research direction for collecting more data that enables the development of deployable SLP models is creating tools that can simplify or automate parts of the collection and annotation process. One of the most significant bottlenecks in obtaining more adequate signed language data is the time and scarcity of experts required to perform annotation. Therefore, tools that perform automatic parsing, detection of frame boundaries, extraction of articulatory features, suggestions for lexical annotations, and allow parts of the annotation process to be crowdsourced to non-experts, to name a few, have a high potential to facilitate and accelerate the availability of good data.
+<<<<<<< HEAD
 Targeting prosodic non-manual annotation specifically, @susman-kimmelman-2024-eye trained a CNN classifier of eye openness (open, in-between, closed) on French Sign Language data and combined it with rule-based temporal aggregation to detect linguistically defined eye blinks, outperforming an Eye Aspect Ratio (EAR) baseline computed from MediaPipe landmarks.
+=======
+In this direction, @otterspeer-etal-2024-signcollect introduce SignCollect, a 'touchless' multi-view recording pipeline using MediaPipe gesture recognition to let a lone signer capture 60--120 lexical entries per hour and publish them to Global Signbank without assisting staff.
+>>>>>>> ee98625 (Add SignCollect (Otterspeer et al., 2024) to Automating Annotation)
 
 ### Practice Deaf Collaboration
 

--- a/src/references.bib
+++ b/src/references.bib
@@ -4788,3 +4788,36 @@ Schulder, Marc},
  url = {https://aclanthology.org/2024.signlang-1.25},
  year = {2024}
 }
+
+    title = "Quantitative Analysis of Hand Locations in both Sign Language and Non-linguistic Gesture Videos",
+    author = "Mart{\'i}nez-Guevara, Niels  and
+      Curiel, Arturo",
+}
+
+@inproceedings{otterspeer-etal-2024-signcollect,
+    title = "{S}ign{C}ollect: A `Touchless' Pipeline for Constructing Large-scale Sign Language Repositories",
+    author = "Otterspeer, Gom{\`e}r  and
+      Klomp, Ulrika  and
+      Roelofsen, Floris",
+    editor = "Efthimiou, Eleni  and
+      Fotinea, Stavroula-Evita  and
+      Hanke, Thomas  and
+      Hochgesang, Julie A.  and
+      Mesch, Johanna  and
+      Schulder, Marc",
+    booktitle = "Proceedings of the LREC-COLING 2024 11th Workshop on the Representation and Processing of Sign Languages: Evaluation of Sign Language Resources",
+    month = may,
+    year = "2024",
+    address = "Torino, Italia",
+    publisher = "ELRA and ICCL",
+    url = "https://aclanthology.org/2024.signlang-1.22/",
+    pages = "204--212"
+}
+
+    url = "https://aclanthology.org/2024.signlang-1.25/",
+    pages = "225--234"
+}
+
+    url = "https://aclanthology.org/2024.signlang-1.30/",
+    pages = "269--275"
+}


### PR DESCRIPTION
## Summary
- Add a one-line citation of @otterspeer-etal-2024-signcollect to the "Automating Annotation" subsection under "Collect Real-World Data".
- Append the corresponding ACL Anthology BibTeX entry to `src/references.bib`.

The paper (LREC-COLING 2024, SignLang Workshop) introduces SignCollect, a 'touchless' multi-view recording pipeline that uses MediaPipe gesture recognition to let a lone Deaf signer record 60-120 NGT lexical entries per hour and publish them to Global Signbank without assisting staff. Code: https://github.com/rem0g/signCollect

## Test plan
- [ ] Verify citation key resolves in `src/references.bib`.
- [ ] Confirm the new sentence renders in the "Automating Annotation" section.

Generated with Claude Code