### PR TITLE
Add VisuoLab platform reference (Rathmann et al., 2024)

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1279,6 +1279,7 @@ datasets.md
 ## Other Resources
 
 - iReviews had compiled a list of [Top Resources for Learning (American) Sign Language](https://www.ireviews.com/sign-language-resources)
+- @rathmann-etal-2024-visuolab present [VisuoLab](https://visuolab.levantelab.com.br/), an open-source multilingual, multimodal, and multifunctional platform built around sign-language-first interfaces for producing video-books and didactic materials, indexing sign language content, and supporting collaborative learning, assessment, and translation/interpretation training.
 
 ## Citation
 

--- a/src/references.bib
+++ b/src/references.bib
@@ -4473,3 +4473,27 @@ Schulder, Marc},
  url = {https://aclanthology.org/2024.signlang-1.24},
  year = {2024}
 }
+
+@inproceedings{rathmann-etal-2024-visuolab,
+    title = "{V}isuo{L}ab: Building a sign language multilingual, multimodal and multifunctional platform",
+    author = "Rathmann, Christian  and
+      de Quadros, Ronice Muller  and
+      Gei{\ss}ler, Thomas  and
+      Peters, Christian  and
+      Fernandes, Francisco  and
+      Loio, Milene Peixer  and
+      Fran{\c{c}}a, Diego",
+    editor = "Efthimiou, Eleni  and
+      Fotinea, Stavroula-Evita  and
+      Hanke, Thomas  and
+      Hochgesang, Julie A.  and
+      Mesch, Johanna  and
+      Schulder, Marc",
+    booktitle = "Proceedings of the LREC-COLING 2024 11th Workshop on the Representation and Processing of Sign Languages: Evaluation of Sign Language Resources",
+    month = may,
+    year = "2024",
+    address = "Torino, Italia",
+    publisher = "ELRA and ICCL",
+    url = "https://aclanthology.org/2024.signlang-1.32/",
+    pages = "282--289"
+}


### PR DESCRIPTION
## Summary
- Adds a one-sentence reference to VisuoLab, an open-source multilingual/multimodal/multifunctional sign language platform, in the Other Resources section.
- Appends the bibtex entry for `rathmann-etal-2024-visuolab` (2024.signlang-1.32) to `src/references.bib`.

## Test plan
- [ ] Verify the citation renders correctly in the Other Resources section.
- [ ] Confirm the bibtex entry resolves the citation key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)