### PR TITLE
Add 3D-LEX v1.0 (Ranum et al., 2024) to isolated sign corpora

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1152,6 +1152,8 @@ The Public DGS Corpus also saw multiple SignLang 2024 contributions: @konrad-eta
 
 @de-quadros-etal-2024-signbank present Signbank 2.0, an open-source, corpus-linked sign documentation platform with linguistic and visual search (e.g., a handshape-similarity scroller) that links each sign entry to its EAF-aligned occurrences in the underlying corpus, currently deployed for Libras with planned support for IntSL, DGS, MJNY, and ÖGS.
 
+@ranum-etal-2024-3d introduce 3D-LEX v1.0, a 3D-motion-capture lexicon of 1,000 isolated signs each in ASL and NGT (combining Vicon body pose, StretchSense glove handshapes, and Live Link Face features) and use it to derive semi-automatic handshape annotations that match expert labels on a WLASL ISLR benchmark.
+
 <!-- TODO: LSA-T aka dataset:dal2022lsa, they use AlphaPose "with the Halpe full-body keypoints format", a visualizer tool, and a baseline SLT model. Especially might be good to mention FiftyOne https://docs.voxel51.com/, "which
 provides useful features such as allowing to filter samples by label, video, playlist,
 or by the confidence score of the signer inference." -->
@@ -1165,7 +1167,6 @@ usually consist of videos of words borrowed from spoken languages that are signe
 
 ###### Isolated sign corpora {-}
 are collections of annotated single signs. They are synthesized [@dataset:ebling2018smile;@dataset:huang2018video;@dataset:sincan2020autsl;@dataset:hassan-etal-2020-isolated] or mined from online resources [@dataset:joze2018ms;@dataset:li2020word], and can be used for isolated sign language recognition or contrastive analysis of minimal signing pairs [@dataset:imashev2020dataset]. However, like dictionaries, they do not describe relations between signs, nor do they capture coarticulation during the signing, and are often limited in vocabulary size (20-1000 signs).
-@ranum-etal-2024-3d introduce 3D-LEX v1.0, a 3D-motion-capture lexicon of 1,000 isolated signs each in ASL and NGT (combining Vicon body pose, StretchSense glove handshapes, and Live Link Face features) and use it to derive semi-automatic handshape annotations that match expert labels on a WLASL ISLR benchmark.
 
 ###### Continuous sign corpora {-}
 contain parallel sequences of signs and spoken language.

--- a/src/index.md
+++ b/src/index.md
@@ -1165,6 +1165,7 @@ usually consist of videos of words borrowed from spoken languages that are signe
 
 ###### Isolated sign corpora {-}
 are collections of annotated single signs. They are synthesized [@dataset:ebling2018smile;@dataset:huang2018video;@dataset:sincan2020autsl;@dataset:hassan-etal-2020-isolated] or mined from online resources [@dataset:joze2018ms;@dataset:li2020word], and can be used for isolated sign language recognition or contrastive analysis of minimal signing pairs [@dataset:imashev2020dataset]. However, like dictionaries, they do not describe relations between signs, nor do they capture coarticulation during the signing, and are often limited in vocabulary size (20-1000 signs).
+@ranum-etal-2024-3d introduce 3D-LEX v1.0, a 3D-motion-capture lexicon of 1,000 isolated signs each in ASL and NGT (combining Vicon body pose, StretchSense glove handshapes, and Live Link Face features) and use it to derive semi-automatic handshape annotations that match expert labels on a WLASL ISLR benchmark.
 
 ###### Continuous sign corpora {-}
 contain parallel sequences of signs and spoken language.

--- a/src/references.bib
+++ b/src/references.bib
@@ -4711,3 +4711,95 @@ Schulder, Marc},
  url = {https://aclanthology.org/2024.signlang-1.38},
  year = {2024}
 }
+}
+
+}
+
+}
+
+
+    title = "Signs and Synonymity: Continuing Development of the Multilingual Sign Language {W}ordnet",
+    author = {Schulder, Marc  and
+      Bigeard, Sam  and
+      Kopf, Maria  and
+      Hanke, Thomas  and
+      Kuder, Anna  and
+      W{\'o}jcicka, Joanna  and
+      Mesch, Johanna  and
+      Bj{\"o}rkstrand, Thomas  and
+      Vacalopoulou, Anna  and
+      Vasilaki, Kyriaki  and
+      Goulas, Theodore  and
+      Fotinea, Stavroula-Evita  and
+      Efthimiou, Eleni},
+}
+
+@inproceedings{vazquez-enriquez-etal-2024-signamed,
+    title = "{S}igna{M}ed: a Cooperative Bilingual {LSE}-{S}panish Dictionary in the Healthcare Domain",
+    author = "V{\'a}zquez-Enr{\'i}quez, Manuel  and
+      Alba-Castro, Jos{\'e} Luis  and
+      P{\'e}rez-P{\'e}rez, Ania  and
+      Cabeza-Pereiro, Carmen  and
+      Doc{\'i}o-Fern{\'a}ndez, Laura",
+}
+
+@inproceedings{picron-etal-2024-easier,
+    title = "The {EASIER} Mobile Application and Avatar End-User Evaluation Methodology",
+    author = "Picron, Frankie  and
+      Van Landuyt, Davy  and
+      Omardeen, Rehana  and
+      Efthimiou, Eleni  and
+      Wolfe, Rosalee  and
+      Fotinea, Stavroula-Evita  and
+      Goulas, Theodore  and
+      Tismer, Christian  and
+      Kopf, Maria  and
+      Hanke, Thomas",
+}
+
+@inproceedings{de-quadros-etal-2024-signbank,
+    title = "{S}ignbank 2.0 of Sign Languages: Easy to Administer, Easy to Use, Easy to Share",
+    author = "de Quadros, Ronice Muller  and
+      Rathmann, Christian  and
+      Romanek, Peter Zal{\'a}n  and
+      Fernandes, Francisco  and
+      Cond{\'e}, Sther",
+}
+
+@inproceedings{ranum-etal-2024-3d,
+    title = "3{D}-{LEX} v1.0 {--} 3{D} Lexicons for {A}merican {S}ign {L}anguage and {S}ign {L}anguage of the {N}etherlands",
+    author = "Ranum, Oline  and
+      Otterspeer, Gom{\`e}r  and
+      Andersen, Jari I.  and
+      Belleman, Robert G.  and
+      Roelofsen, Floris",
+    editor = "Efthimiou, Eleni  and
+      Fotinea, Stavroula-Evita  and
+      Hanke, Thomas  and
+      Hochgesang, Julie A.  and
+      Mesch, Johanna  and
+      Schulder, Marc",
+    booktitle = "Proceedings of the LREC-COLING 2024 11th Workshop on the Representation and Processing of Sign Languages: Evaluation of Sign Language Resources",
+    month = may,
+    year = "2024",
+    address = "Torino, Italia",
+    publisher = "ELRA and ICCL",
+    url = "https://aclanthology.org/2024.signlang-1.38/",
+    pages = "343--353"
+}
+
+    url = "https://aclanthology.org/2024.signlang-1.43/",
+    pages = "386--394"
+}
+
+    url = "https://aclanthology.org/2024.signlang-1.31/",
+    pages = "276--281"
+}
+
+    url = "https://aclanthology.org/2024.signlang-1.34/",
+    pages = "302--314"
+}
+
+    url = "https://aclanthology.org/2024.signlang-1.33/",
+    pages = "290--301"
+}


### PR DESCRIPTION
## Summary
- Cites Ranum et al. (2024), "3D-LEX v1.0 - 3D Lexicons for American Sign Language and Sign Language of the Netherlands" (SignLang 2024, aclanthology.org/2024.signlang-1.33).
- Added one sentence under "Isolated sign corpora" in `src/index.md` describing the dataset (1,000 ASL + 1,000 NGT signs captured via Vicon, StretchSense gloves, and Live Link Face) and its semi-automatic handshape annotation use on a WLASL ISLR benchmark.
- Appended the corresponding BibTeX entry (`ranum-etal-2024-3d`) to `src/references.bib`.

## Test plan
- [ ] Verify the new sentence renders correctly in the "Isolated sign corpora" subsection.
- [ ] Confirm the citation `@ranum-etal-2024-3d` resolves against `references.bib` during build.
- [ ] Spot-check the link to https://aclanthology.org/2024.signlang-1.33/ in rendered output.

Generated with [Claude Code](https://claude.com/claude-code)