### PR TITLE
Add Roh et al. 2024: MediaPipe keypoint preprocessing for ISLR

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -569,7 +569,7 @@ they combine the phonological annotations in ASL-LEX 2.0 [@dataset:sehyr2021asl]
 Interestingly, @tavella-etal-2022-wlasl construct a similar dataset aiming just for phonological property recognition in American Sign Language (ASL).
 @inoue-etal-2024-enhancing trained a Video-Keypoint Network (VKNet) to classify the location, movement, and handshape syllabic components of the dominant hand in Japanese Sign Language (JSL), and demonstrated that pre-training on the WLASL American Sign Language (ASL) dataset improved classification of the movement and handshape components when JSL training data was limited.
 
-@roh-etal-2024-preprocessing focus on preprocessing MediaPipe keypoints for isolated SLR by introducing palm-anchor-based normalization to emphasize hand shape and bilinear interpolation to reconstruct undetected hand keypoints, achieving 83.26% accuracy on WLASL-100 with a Transformer encoder, the highest among pose-based approaches at the time.
+@roh-etal-2024-preprocessing focus on preprocessing MediaPipe keypoints for isolated SLR by introducing palm-anchor-based normalization to emphasize hand shape and bilinear interpolation to reconstruct undetected hand keypoints, achieving the highest accuracy on WLASL-100 with a Transformer encoder among pose-based approaches at the time.
 
 #### Gloss-to-Pose
 Gloss-to-Pose, subsumed under the task of sign language production, is the task of producing a sequence of poses that adequately represent

--- a/src/index.md
+++ b/src/index.md
@@ -569,6 +569,8 @@ they combine the phonological annotations in ASL-LEX 2.0 [@dataset:sehyr2021asl]
 Interestingly, @tavella-etal-2022-wlasl construct a similar dataset aiming just for phonological property recognition in American Sign Language (ASL).
 @inoue-etal-2024-enhancing trained a Video-Keypoint Network (VKNet) to classify the location, movement, and handshape syllabic components of the dominant hand in Japanese Sign Language (JSL), and demonstrated that pre-training on the WLASL American Sign Language (ASL) dataset improved classification of the movement and handshape components when JSL training data was limited.
 
+@roh-etal-2024-preprocessing focus on preprocessing MediaPipe keypoints for isolated SLR by introducing palm-anchor-based normalization to emphasize hand shape and bilinear interpolation to reconstruct undetected hand keypoints, achieving 83.26% accuracy on WLASL-100 with a Transformer encoder, the highest among pose-based approaches at the time.
+
 #### Gloss-to-Pose
 Gloss-to-Pose, subsumed under the task of sign language production, is the task of producing a sequence of poses that adequately represent
 a sequence of signs written as gloss.

--- a/src/references.bib
+++ b/src/references.bib
@@ -4545,6 +4545,15 @@ Schulder, Marc},
       Chen, Yuxiao  and
       Neidle, Carol  and
       Metaxas, Dimitris N.",
+}
+
+@inproceedings{roh-etal-2024-preprocessing,
+    title = "Preprocessing Mediapipe Keypoints with Keypoint Reconstruction and Anchors for Isolated Sign Language Recognition",
+    author = "Roh, Kyunggeun  and
+      Lee, Huije  and
+      Hwang, Eui Jun  and
+      Cho, Sukmin  and
+      Park, Jong C.",
     editor = "Efthimiou, Eleni  and
       Fotinea, Stavroula-Evita  and
       Hanke, Thomas  and
@@ -4558,4 +4567,8 @@ Schulder, Marc},
     publisher = "ELRA and ICCL",
     url = "https://aclanthology.org/2024.signlang-1.45/",
     pages = "408--419"
+}
+
+    url = "https://aclanthology.org/2024.signlang-1.36/",
+    pages = "323--334"
 }


### PR DESCRIPTION
## Summary
- Adds @roh-etal-2024-preprocessing to the Pose-to-Gloss section of the survey.
- Paper introduces palm-anchor-based hand normalization and bilinear-interpolation hand keypoint reconstruction for MediaPipe outputs, evaluated on WLASL-100 and AUTSL with a Transformer encoder.
- Appends BibTeX entry to references.bib.

## Test plan
- [ ] Verify citation renders correctly in the built site.
- [ ] Confirm BibTeX entry has no duplicate key.

Generated with Claude Code