### PR TITLE
Cite Susman & Kimmelman 2024: CNN+rule-based eye blink detection in LSF

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1175,6 +1175,7 @@ Therefore, data collection often requires significant efforts and costs of on-si
 
 ###### Automating Annotation {-}
 One helpful research direction for collecting more data that enables the development of deployable SLP models is creating tools that can simplify or automate parts of the collection and annotation process. One of the most significant bottlenecks in obtaining more adequate signed language data is the time and scarcity of experts required to perform annotation. Therefore, tools that perform automatic parsing, detection of frame boundaries, extraction of articulatory features, suggestions for lexical annotations, and allow parts of the annotation process to be crowdsourced to non-experts, to name a few, have a high potential to facilitate and accelerate the availability of good data.
+Targeting prosodic non-manual annotation specifically, @susman-kimmelman-2024-eye trained a CNN classifier of eye openness (open, in-between, closed) on French Sign Language data and combined it with rule-based temporal aggregation to detect linguistically defined eye blinks, outperforming an EAR-based baseline using MediaPipe landmarks.
 
 ### Practice Deaf Collaboration
 

--- a/src/index.md
+++ b/src/index.md
@@ -1175,7 +1175,7 @@ Therefore, data collection often requires significant efforts and costs of on-si
 
 ###### Automating Annotation {-}
 One helpful research direction for collecting more data that enables the development of deployable SLP models is creating tools that can simplify or automate parts of the collection and annotation process. One of the most significant bottlenecks in obtaining more adequate signed language data is the time and scarcity of experts required to perform annotation. Therefore, tools that perform automatic parsing, detection of frame boundaries, extraction of articulatory features, suggestions for lexical annotations, and allow parts of the annotation process to be crowdsourced to non-experts, to name a few, have a high potential to facilitate and accelerate the availability of good data.
-Targeting prosodic non-manual annotation specifically, @susman-kimmelman-2024-eye trained a CNN classifier of eye openness (open, in-between, closed) on French Sign Language data and combined it with rule-based temporal aggregation to detect linguistically defined eye blinks, outperforming an EAR-based baseline using MediaPipe landmarks.
+Targeting prosodic non-manual annotation specifically, @susman-kimmelman-2024-eye trained a CNN classifier of eye openness (open, in-between, closed) on French Sign Language data and combined it with rule-based temporal aggregation to detect linguistically defined eye blinks, outperforming an Eye Aspect Ratio (EAR) baseline computed from MediaPipe landmarks.
 
 ### Practice Deaf Collaboration
 

--- a/src/references.bib
+++ b/src/references.bib
@@ -4496,3 +4496,22 @@ Schulder, Marc},
  url = {https://aclanthology.org/2024.signlang-1.32},
  year = {2024}
 }
+
+@inproceedings{susman-kimmelman-2024-eye,
+    title = "Eye Blink Detection in Sign Language Data Using {CNN}s and Rule-Based Methods",
+    author = "Susman, Margaux  and
+      Kimmelman, Vadim",
+    editor = "Efthimiou, Eleni  and
+      Fotinea, Stavroula-Evita  and
+      Hanke, Thomas  and
+      Hochgesang, Julie A.  and
+      Mesch, Johanna  and
+      Schulder, Marc",
+    booktitle = "Proceedings of the LREC-COLING 2024 11th Workshop on the Representation and Processing of Sign Languages: Evaluation of Sign Language Resources",
+    month = may,
+    year = "2024",
+    address = "Torino, Italia",
+    publisher = "ELRA and ICCL",
+    url = "https://aclanthology.org/2024.signlang-1.40/",
+    pages = "361--369"
+}


### PR DESCRIPTION
## Summary
- Adds a one-sentence citation of @susman-kimmelman-2024-eye (SignLang 2024) in the Automating Annotation section.
- Paper trains a CNN to classify eye openness (open / in-between / closed) on French Sign Language data and combines it with rule-based temporal aggregation to detect linguistically defined blinks; compared against an EAR-based MediaPipe baseline.
- Code/data: https://osf.io/dth2q/

## Test plan
- [ ] Confirm citation key resolves in references.bib
- [ ] Confirm rendered HTML/PDF builds without warnings

Generated with Claude Code