### PR TITLE
Add SEDA (Tan et al., 2024) to Video-to-Text section

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -744,7 +744,7 @@ On this encoding, they use a Connectionist Temporal Classification (CTC) [@grave
 Using the same encoding, they use a transformer decoder to decode the spoken language text one token at a time.
 They show that adding gloss supervision improves the model over not using it and that it outperforms previous video-to-gloss-to-text pipeline approaches [@cihan2018neural].
 
-@tan-etal-2024-seda extend this sign language transformer with SEDA, a simple and effective data augmentation framework that augments sign features by passing the same frames through multiple sign embeddings (the original spatial embedding plus a frozen spatial-temporal embedding distilled from a self-mutual knowledge distillation model) and augments spoken text via lemmatization and alphabet normalization, then trains both views jointly with multi-task learning followed by task-specific fine-tuning to achieve competitive WER, BLEU, and ROUGE on RWTH-PHOENIX-Weather-2014T.
+@tan-etal-2024-seda extend this sign language transformer with SEDA, a data augmentation framework that augments sign features through multiple sign embeddings and augments spoken text via lemmatization, achieving competitive WER, BLEU, and ROUGE on RWTH-PHOENIX-Weather-2014T.
 
 Following up, @camgoz2020multi propose a new architecture that does not require the supervision of glosses, named "Multi-channel Transformers for Multi-articulatory Sign Language Translation".
 In this approach, they crop the signing hand and the face and perform 3D pose estimation to obtain three separate data channels.

--- a/src/index.md
+++ b/src/index.md
@@ -744,6 +744,8 @@ On this encoding, they use a Connectionist Temporal Classification (CTC) [@grave
 Using the same encoding, they use a transformer decoder to decode the spoken language text one token at a time.
 They show that adding gloss supervision improves the model over not using it and that it outperforms previous video-to-gloss-to-text pipeline approaches [@cihan2018neural].
 
+@tan-etal-2024-seda extend this sign language transformer with SEDA, a simple and effective data augmentation framework that augments sign features by passing the same frames through multiple sign embeddings (the original spatial embedding plus a frozen spatial-temporal embedding distilled from a self-mutual knowledge distillation model) and augments spoken text via lemmatization and alphabet normalization, then trains both views jointly with multi-task learning followed by task-specific fine-tuning to achieve competitive WER, BLEU, and ROUGE on RWTH-PHOENIX-Weather-2014T.
+
 Following up, @camgoz2020multi propose a new architecture that does not require the supervision of glosses, named "Multi-channel Transformers for Multi-articulatory Sign Language Translation".
 In this approach, they crop the signing hand and the face and perform 3D pose estimation to obtain three separate data channels.
 They encode each data channel separately using a transformer, then encode all channels together and concatenate the separate channels for each frame.

--- a/src/index.md
+++ b/src/index.md
@@ -744,8 +744,6 @@ On this encoding, they use a Connectionist Temporal Classification (CTC) [@grave
 Using the same encoding, they use a transformer decoder to decode the spoken language text one token at a time.
 They show that adding gloss supervision improves the model over not using it and that it outperforms previous video-to-gloss-to-text pipeline approaches [@cihan2018neural].
 
-@tan-etal-2024-seda extend this sign language transformer with SEDA, a data augmentation framework that augments sign features through multiple sign embeddings and augments spoken text via lemmatization, achieving competitive WER, BLEU, and ROUGE on RWTH-PHOENIX-Weather-2014T.
-
 Following up, @camgoz2020multi propose a new architecture that does not require the supervision of glosses, named "Multi-channel Transformers for Multi-articulatory Sign Language Translation".
 In this approach, they crop the signing hand and the face and perform 3D pose estimation to obtain three separate data channels.
 They encode each data channel separately using a transformer, then encode all channels together and concatenate the separate channels for each frame.
@@ -803,6 +801,8 @@ They find that while pretraining with blurring hurts performance, some can be re
 SSVP-SLT achieves state-of-the-art performance on How2Sign [@dataset:duarte2020how2sign].
 They conclude that SLT models can be pretrained in a privacy-aware manner without sacrificing too much performance.
 Additionally, the authors release DailyMoth-70h, a new 70-hour ASL dataset from [The Daily Moth](https://www.dailymoth.com/).
+
+@tan-etal-2024-seda extend this sign language transformer with SEDA, a data augmentation framework that augments sign features through multiple sign embeddings and augments spoken text via lemmatization, achieving competitive WER, BLEU, and ROUGE on RWTH-PHOENIX-Weather-2014T.
 
 #### Text-to-Video
 Text-to-Video, also known as sign language production, is the task of producing a video that adequately represents

--- a/src/references.bib
+++ b/src/references.bib
@@ -4782,6 +4782,14 @@ Schulder, Marc},
     author = "Reverdy, Cl{\'e}ment  and
       Gibet, Sylvie  and
       Le Naour, Thibaut",
+}
+
+@inproceedings{tan-etal-2024-seda,
+    title = "{SEDA}: Simple and Effective Data Augmentation for Sign Language Understanding",
+    author = "Tan, Sihan  and
+      Miyazaki, Taro  and
+      Itoyama, Katsutoshi  and
+      Nakadai, Kazuhiro",
     editor = "Efthimiou, Eleni  and
       Fotinea, Stavroula-Evita  and
       Hanke, Thomas  and
@@ -4815,4 +4823,8 @@ Schulder, Marc},
 
     url = "https://aclanthology.org/2024.signlang-1.35/",
     pages = "315--322"
+}
+
+    url = "https://aclanthology.org/2024.signlang-1.41/",
+    pages = "370--375"
 }


### PR DESCRIPTION
## Summary
- Adds a citation and one-sentence description of SEDA (Tan et al., 2024) in the Video-to-Text section, situating it as a multi-task data-augmentation extension to the sign language transformer baseline.
- Appends the corresponding BibTeX entry (key `tan-etal-2024-seda`) to `src/references.bib`.

## Test plan
- [ ] Confirm the new sentence renders correctly and the citation key resolves.
- [ ] Verify no broken references after the addition.

Paper: https://aclanthology.org/2024.signlang-1.41/

Generated with Claude Code