### PR TITLE
Add SignaMed (Vazquez-Enriquez et al., 2024) to bilingual dictionaries

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1147,6 +1147,8 @@ The Public DGS Corpus also saw multiple SignLang 2024 contributions: @konrad-eta
 
 @schulder-etal-2024-signs continue development of the Multilingual Sign Language Wordnet (MSL-WN), which links signs from eight sign languages (BSL, DGS, DSGS, GSL, LSF, NGT, PJM, STS) to Open Multilingual Wordnet synsets and introduces a synonymity-based annotation feature that leverages partial synonymy between signs to suggest cross-lingual sign-synset connections.
 
+@vazquez-enriquez-etal-2024-signamed present SignaMed, a domain-specific bilingual LSE-Spanish dictionary for healthcare that supports webcam-based sign lookup via an isolated sign recognition model and grows iteratively through curated Deaf-community sign donations.
+
 <!-- TODO: LSA-T aka dataset:dal2022lsa, they use AlphaPose "with the Halpe full-body keypoints format", a visualizer tool, and a baseline SLT model. Especially might be good to mention FiftyOne https://docs.voxel51.com/, "which
 provides useful features such as allowing to filter samples by label, video, playlist,
 or by the confidence score of the signer inference." -->
@@ -1154,7 +1156,6 @@ or by the confidence score of the signer inference." -->
 ###### Bilingual dictionaries {-}
 for signed language [@dataset:mesch2012meaning;@fenlon2015building;@crasborn2016ngt;@dataset:gutierrez2016lse] map a spoken language word or short phrase to a signed language video.
 One notable dictionary, SpreadTheSign\footnote{\url{https://www.spreadthesign.com/}} is a parallel dictionary containing around 25,000 words with up to 42 different spoken-signed language pairs and more than 600,000 videos in total. Unfortunately, while dictionaries may help create lexical rules between languages, they do not demonstrate the grammar or the usage of signs in context.
-@vazquez-enriquez-etal-2024-signamed present SignaMed, a domain-specific bilingual LSE-Spanish dictionary for healthcare that supports webcam-based sign lookup via an isolated sign recognition model and grows iteratively through curated Deaf-community sign donations.
 
 ###### Fingerspelling corpora {-}
 usually consist of videos of words borrowed from spoken languages that are signed letter-by-letter. They can be synthetically created [@dataset:dreuw2006modeling] or mined from online resources [@dataset:fs18slt;@dataset:fs18iccv]. However, they only capture one aspect of signed languages.

--- a/src/index.md
+++ b/src/index.md
@@ -1154,6 +1154,7 @@ or by the confidence score of the signer inference." -->
 ###### Bilingual dictionaries {-}
 for signed language [@dataset:mesch2012meaning;@fenlon2015building;@crasborn2016ngt;@dataset:gutierrez2016lse] map a spoken language word or short phrase to a signed language video.
 One notable dictionary, SpreadTheSign\footnote{\url{https://www.spreadthesign.com/}} is a parallel dictionary containing around 25,000 words with up to 42 different spoken-signed language pairs and more than 600,000 videos in total. Unfortunately, while dictionaries may help create lexical rules between languages, they do not demonstrate the grammar or the usage of signs in context.
+@vazquez-enriquez-etal-2024-signamed present SignaMed, a domain-specific bilingual LSE-Spanish dictionary for healthcare that supports webcam-based sign lookup via an isolated sign recognition model and grows iteratively through curated Deaf-community sign donations.
 
 ###### Fingerspelling corpora {-}
 usually consist of videos of words borrowed from spoken languages that are signed letter-by-letter. They can be synthetically created [@dataset:dreuw2006modeling] or mined from online resources [@dataset:fs18slt;@dataset:fs18iccv]. However, they only capture one aspect of signed languages.

--- a/src/references.bib
+++ b/src/references.bib
@@ -4711,3 +4711,45 @@ Schulder, Marc},
  url = {https://aclanthology.org/2024.signlang-1.38},
  year = {2024}
 }
+
+    title = "Signs and Synonymity: Continuing Development of the Multilingual Sign Language {W}ordnet",
+    author = {Schulder, Marc  and
+      Bigeard, Sam  and
+      Kopf, Maria  and
+      Hanke, Thomas  and
+      Kuder, Anna  and
+      W{\'o}jcicka, Joanna  and
+      Mesch, Johanna  and
+      Bj{\"o}rkstrand, Thomas  and
+      Vacalopoulou, Anna  and
+      Vasilaki, Kyriaki  and
+      Goulas, Theodore  and
+      Fotinea, Stavroula-Evita  and
+      Efthimiou, Eleni},
+}
+
+@inproceedings{vazquez-enriquez-etal-2024-signamed,
+    title = "{S}igna{M}ed: a Cooperative Bilingual {LSE}-{S}panish Dictionary in the Healthcare Domain",
+    author = "V{\'a}zquez-Enr{\'i}quez, Manuel  and
+      Alba-Castro, Jos{\'e} Luis  and
+      P{\'e}rez-P{\'e}rez, Ania  and
+      Cabeza-Pereiro, Carmen  and
+      Doc{\'i}o-Fern{\'a}ndez, Laura",
+    editor = "Efthimiou, Eleni  and
+      Fotinea, Stavroula-Evita  and
+      Hanke, Thomas  and
+      Hochgesang, Julie A.  and
+      Mesch, Johanna  and
+      Schulder, Marc",
+    booktitle = "Proceedings of the LREC-COLING 2024 11th Workshop on the Representation and Processing of Sign Languages: Evaluation of Sign Language Resources",
+    month = may,
+    year = "2024",
+    address = "Torino, Italia",
+    publisher = "ELRA and ICCL",
+    url = "https://aclanthology.org/2024.signlang-1.38/",
+    pages = "343--353"
+}
+
+    url = "https://aclanthology.org/2024.signlang-1.43/",
+    pages = "386--394"
+}


### PR DESCRIPTION
## Summary
- Adds a one-sentence reference to SignaMed, a cooperative bilingual LSE-Spanish dictionary in the healthcare domain, in the Bilingual dictionaries subsection of Resources.
- SignaMed uses an isolated sign recognition (ISLR, MSG3D-based) model to support webcam-based sign lookup and grows iteratively via curated Deaf-community sign donations.
- Appends the corresponding bibtex entry from the ACL Anthology.

## Test plan
- [x] Verify citation key resolves in both src/index.md and src/references.bib
- [ ] Confirm rendered page lists the new sentence under "Bilingual dictionaries"

Paper: https://aclanthology.org/2024.signlang-1.43/

Generated with Claude Code