### PR TITLE
Add Uchida et al. (2024) HamNoSys-based motion editing for JSL avatars

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -877,6 +877,8 @@ Then, starting from a still frame they used an iterative non-autoregressive deco
 In each time step $t$ from $T$ to $1$, the model predicts the required change from step $t$ to step $t-1$. After $T$ steps, the pose generator outputs the final pose sequence.
 Their model outperformed previous methods like @saunders2020progressive, animating HamNoSys into more realistic sign language sequences.
 
+@uchida-etal-2024-hamnosys proposed a HamNoSys-based motion editing method for Japanese Sign Language that edits handshape, hand orientation, and location of pre-recorded motion-capture data via FABRIK inverse kinematics and a wrist-offset technique to reproduce contextual modifications such as classifier predicates without additional motion-capture recordings.
+
 #### Evaluation Metrics
 
 Methods for automatic evaluation of sign language processing are typically dependent only on the output and independent of the input.

--- a/src/references.bib
+++ b/src/references.bib
@@ -4348,3 +4348,23 @@ Schulder, Marc},
  url = {https://aclanthology.org/2024.signlang-1.14},
  year = {2024}
 }
+
+@inproceedings{uchida-etal-2024-hamnosys,
+    title = "{H}am{N}o{S}ys-based Motion Editing Method for Sign Language",
+    author = "Uchida, Tsubasa  and
+      Miyazaki, Taro  and
+      Kaneko, Hiroyuki",
+    editor = "Efthimiou, Eleni  and
+      Fotinea, Stavroula-Evita  and
+      Hanke, Thomas  and
+      Hochgesang, Julie A.  and
+      Mesch, Johanna  and
+      Schulder, Marc",
+    booktitle = "Proceedings of the LREC-COLING 2024 11th Workshop on the Representation and Processing of Sign Languages: Evaluation of Sign Language Resources",
+    month = may,
+    year = "2024",
+    address = "Torino, Italia",
+    publisher = "ELRA and ICCL",
+    url = "https://aclanthology.org/2024.signlang-1.42/",
+    pages = "376--385"
+}


### PR DESCRIPTION
## Summary
- Cites Uchida et al. (2024), "HamNoSys-based Motion Editing Method for Sign Language" (2024.signlang-1.42) under the Notation-to-Pose section.
- Describes their hybrid MoCap/HamNoSys editing method using FABRIK IK and a wrist-offset technique to reproduce contextual modifications (e.g., classifier predicates) on motion-captured citation forms.
- Appends the corresponding BibTeX entry to references.bib.

## Test plan
- [ ] Verify the citation renders correctly in the Notation-to-Pose section.
- [ ] Verify the bibliography entry appears with correct metadata.

Generated with Claude Code