### PR TITLE
Add DiffSLVA (Xia et al., 2024) to SLVA discussion

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -438,6 +438,7 @@ retaining the original sign language content.
 Using a conditional variational autoencoder framework, they first extracted pose information from the source video to remove the original signer appearance,
 then generated a photo-realistic sign language video of a novel appearance from the pose sequence. 
 The authors proposed a novel style loss that ensures style consistency in the anonymized sign language videos. 
+Extending this line of work, @xia-etal-2024-diffusion proposed DiffSLVA, which leverages pre-trained large-scale text-guided latent diffusion models with ControlNet conditioned on Holistically-Nested Edge (HED) maps to circumvent the need for accurate pose estimation, and adds a dedicated facial expression enhancement module to preserve linguistically essential non-manual features.
 
 ##### Sign Language Avatars
 

--- a/src/references.bib
+++ b/src/references.bib
@@ -4354,6 +4354,15 @@ Schulder, Marc},
     author = "Uchida, Tsubasa  and
       Miyazaki, Taro  and
       Kaneko, Hiroyuki",
+}
+
+@inproceedings{xia-etal-2024-diffusion,
+    title = "Diffusion Models for Sign Language Video Anonymization",
+    author = "Xia, Zhaoyang  and
+      Zhou, Yang  and
+      Han, Ligong  and
+      Neidle, Carol  and
+      Metaxas, Dimitris N.",
     editor = "Efthimiou, Eleni  and
       Fotinea, Stavroula-Evita  and
       Hanke, Thomas  and
@@ -4367,4 +4376,8 @@ Schulder, Marc},
     publisher = "ELRA and ICCL",
     url = "https://aclanthology.org/2024.signlang-1.42/",
     pages = "376--385"
+}
+
+    url = "https://aclanthology.org/2024.signlang-1.44/",
+    pages = "395--407"
 }


### PR DESCRIPTION
## Summary
- Cite the SignLang 2024 paper *Diffusion Models for Sign Language Video Anonymization* (Xia, Zhou, Han, Neidle, Metaxas) in the Pose-to-Video / SLVA paragraph in `src/index.md`, immediately following the existing AnonySign discussion.
- Add the corresponding BibTeX entry (`xia-etal-2024-diffusion`) to `src/references.bib`.
- One concise sentence summarizes DiffSLVA's contribution: text-guided latent diffusion + ControlNet conditioned on HED edges (avoiding pose estimation) plus a dedicated facial-expression enhancement module.

Paper: https://aclanthology.org/2024.signlang-1.44/
Code: https://github.com/Jeffery9707/DiffSLVA

## Test plan
- [ ] `make` / site build succeeds
- [ ] `@xia-etal-2024-diffusion` renders correctly in the rendered HTML/PDF
- [ ] Citation appears in the references list

Generated with Claude Code