### PR TITLE
ci: drop pull_request trigger from Format bib (push to master only)

### DIFF
--- a/.github/workflows/format-bib.yml
+++ b/.github/workflows/format-bib.yml
@@ -1,8 +1,6 @@
 name: Format bib
 
 on:
-  pull_request:
-    branches: [ main, master ]
   push:
     branches: [ main, master ]
 


### PR DESCRIPTION
## Summary

The `Format bib` workflow runs rebiber and auto-commits the result back to the branch via `stefanzweifel/git-auto-commit-action`. When triggered on both `push` and `pull_request` events, both runs race to push the auto-commit and one fails with `[rejected] (fetch first)`, turning the check red even though the bib content is fine. (See e.g. the spurious red `Format bib` checks on the recent SignLang 2024 PRs like #143.)

This drops the `pull_request` trigger so the workflow only runs on pushes to `main`/`master`. The auto-formatter still runs (post-merge), and PRs no longer have a flaky `Format bib` check.

## Test plan

- [ ] On merge, the `Format bib` workflow runs once on the master push and the auto-commit succeeds.
- [ ] Future PRs no longer show a `Format bib` check at all.