### PR TITLE
papers: expand crawl with CSV/EML missed-paper seeds

### DIFF
--- a/papers/scripts/resolve_seeds.py
+++ b/papers/scripts/resolve_seeds.py
@@ -1,0 +1,90 @@
+"""Resolve CSV/EML missed-paper titles to Semantic Scholar paperIds and
+inject the new ones into the crawl frontier.
+
+Input : a JSON list of {title, year, src} (path via argv[1]).
+Output: state/seed_csv_eml.json  — {query_title: paperId|null} checkpoint,
+        and the resolved new ids appended to state/frontier.json.
+
+Resumable: re-running skips titles already in seed_csv_eml.json.
+No year filter here — caller pre-filters to post-2014.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+from ss_client import SSClient
+
+STATE = Path(__file__).resolve().parent.parent / "state"
+SEED_OUT = STATE / "seed_csv_eml.json"
+FRONTIER = STATE / "frontier.json"
+VISITED = STATE / "visited.json"
+
+
+def norm(t: str) -> str:
+    return " ".join(re.sub(r"[^a-z0-9]+", " ", (t or "").lower()).split())
+
+
+def title_ok(a: str, b: str) -> bool:
+    a, b = norm(a), norm(b)
+    if a == b:
+        return True
+    s = min(len(a), len(b))
+    return s >= 25 and (a.startswith(b) or b.startswith(a))
+
+
+def main(seeds_path: str) -> None:
+    seeds = json.loads(Path(seeds_path).read_text())
+    resolved = json.loads(SEED_OUT.read_text()) if SEED_OUT.exists() else {}
+    client = SSClient()
+
+    todo = [s for s in seeds if norm(s["title"]) not in resolved]
+    print(f"{len(seeds)} seeds, {len(resolved)} already resolved, {len(todo)} to do", flush=True)
+
+    for i, s in enumerate(todo):
+        q = s["title"]
+        key = norm(q)
+        pid = None
+        try:
+            resp = client.get(
+                "/paper/search/match",
+                {"query": q[:300], "fields": "paperId,title,year"},
+            )
+            data = resp.get("data") or []
+            if data and title_ok(q, data[0].get("title", "")):
+                pid = data[0]["paperId"]
+        except Exception as e:  # noqa: BLE001 — match returns 404 when no hit
+            if "404" not in str(e):
+                print(f"  err {key[:40]}: {e}", flush=True)
+        resolved[key] = pid
+        if (i + 1) % 20 == 0:
+            SEED_OUT.write_text(json.dumps(resolved, ensure_ascii=False))
+            found = sum(1 for v in resolved.values() if v)
+            print(f"  {i + 1}/{len(todo)} resolved; {found} have paperIds", flush=True)
+
+    SEED_OUT.write_text(json.dumps(resolved, ensure_ascii=False))
+
+    # Inject new ids into frontier (skip ones already visited/known).
+    visited = json.loads(VISITED.read_text()) if VISITED.exists() else {}
+    frontier = json.loads(FRONTIER.read_text()) if FRONTIER.exists() else []
+    fset = set(frontier)
+    ids = {v for v in resolved.values() if v}
+    new = [pid for pid in ids if pid not in visited and pid not in fset]
+    frontier.extend(new)
+    tmp = FRONTIER.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(frontier, ensure_ascii=False))
+    tmp.replace(FRONTIER)
+
+    print(
+        f"DONE: {len(ids)} titles resolved to ids; "
+        f"{len(ids & set(visited))} already in crawl; "
+        f"{len(new)} NEW ids added to frontier (now {len(frontier)})",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/papers/state.tar.gz
+++ b/papers/state.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c821661e5e2498e90830591542e6c30f908c28bbc8e1343bcb203cd17d794724
-size 423330512
+oid sha256:82ca5aac5cb0edd43ac45bf0aefa62c2b87577896091bf1662cae84441c2f35e
+size 432691153


### PR DESCRIPTION
## What

Cross-referenced two external Google Scholar exports against the papers crawl to find sign-language papers we never reached, then fed the recoverable ones back in.

- **Sources:** `csv-files.zip` (Publish-or-Perish title exports for `"sign language" + recognition/translation`, pre-2000→2023) and `eml-files.zip` (223 "sign language" Scholar alert emails, 2025–26) — 5,585 unique candidate titles, ~44% not in the crawl.
- **New `scripts/resolve_seeds.py`:** resolves titles → Semantic Scholar paperIds via the title-match endpoint and injects new ids into `state/frontier.json` (resumable).
- Took the **1,568 missed post-2014 SL titles** (≈257 non-SL false positives — semiotics, animal communication, generic gesture, audiology, spam — excluded via an LLM title judge), resolved **634** to SS ids, added **602 new seeds**, and drained the crawl.

## Result (`state.tar.gz` refreshed)

| | Before | After | Δ |
|---|---|---|---|
| Total rendered papers | 15,575 | **16,137** | +562 |
| Papers ≥ 2014 | 11,282 | **11,823** | +541 |

## Notes

- The expansion confirmed the existing crawl had already captured essentially the entire **reachable** SL citation closure: of 555 newly-expanded nodes, only 24 surfaced any new SL neighbor (37 total), and the BFS hit a fixed point in 9 iterations. The added papers were peripheral leaves nothing previously pointed to.
- The remaining **~933 unresolved titles are not indexed on Semantic Scholar** (recent theses, local/regional journals) — unreachable by an SS-based crawl, left out by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)