### PR TITLE
ci: grant deploy workflow contents write permission

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      # Allow the default GITHUB_TOKEN to push the built site to gh-pages
+      contents: write
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.


### PR DESCRIPTION
The "Build and Deploy" workflow has been failing on master since June: the gh-pages push gets a 403 because the default `GITHUB_TOKEN` is read-only and `deploy.yml` never requests write access. `format-bib.yml` already declares `permissions: contents: write` — this adds the same block to the deploy job.

Failing run for reference: https://github.com/sign-language-processing/sign-language-processing.github.io/actions/runs/28778740735

🤖 Generated with [Claude Code](https://claude.com/claude-code)